### PR TITLE
Pause test execution to let containers start up

### DIFF
--- a/services/csharp/IntegrationTest/test.ps1
+++ b/services/csharp/IntegrationTest/test.ps1
@@ -51,6 +51,9 @@ try {
 	# Create containers, and then start them backgrounded.
 	& "docker-compose.exe" -f docker_compose.yml up --no-start
 	& "docker-compose.exe" -f docker_compose.yml start
+
+	Write-Output "Giving containers a chance to start up..."
+	Start-Sleep -s 5
 	
 	if ($test_matchmaking) {
 		Write-Output "Running tests for the Matchmaking system."

--- a/services/csharp/IntegrationTest/test.sh
+++ b/services/csharp/IntegrationTest/test.sh
@@ -71,6 +71,9 @@ trap finish EXIT
 docker-compose -f docker_compose.yml up --no-start
 docker-compose -f docker_compose.yml start
 
+echo "Giving services a chance to start up..."
+sleep 5
+
 # Execute the integration tests depending on the received command line arguments.
 if [ ${test_matchmaking} -eq 0 ]; then
   echo "Running tests for the Matchmaking system."


### PR DESCRIPTION
Integration tests seem a little flakey. I'm assuming this is the cause; I'm not able to reproduce the flake on my machine.