### PR TITLE
SampleMatcher marks used deployments on match

### DIFF
--- a/services/csharp/SampleMatcher/Matcher.cs
+++ b/services/csharp/SampleMatcher/Matcher.cs
@@ -13,6 +13,7 @@ namespace Improbable.OnlineServices.SampleMatcher
         private const int TickMs = 200;
         private readonly string _project;
         private readonly string ReadyTag = "ready"; // This should be the same tag a DeploymentPool looks for.
+        private readonly string InUseTag = "in-use";
         private RepeatedField<WaitingParty> _waitingParties;
 
         public Matcher()
@@ -123,6 +124,7 @@ namespace Improbable.OnlineServices.SampleMatcher
         private void MarkDeploymentAsInUse(DeploymentServiceClient dplClient, Deployment dpl)
         {
             dpl.Tag.Remove(ReadyTag);
+            dpl.Tag.Add(InUseTag);
             var req = new UpdateDeploymentRequest { Deployment = dpl };
             dplClient.UpdateDeployment(req);
         }


### PR DESCRIPTION
Matcher now only finds deployments with the "ready" tag to match against (also modified the request to NOT fetch deployment while we aren't using it (this is slow as it calls the Runtime) and to not return stopped deployments. Both of these should speed up the call.

On a successful match, the matcher removes the "ready" tag so it will not be matched again, and a running Pool will replace it with a new deployment. There is race between matchers to remove this tag, might be worth adding a randomly generated tag to see if multiple matchers call Update at the same time.