### PR TITLE
Fix race condition in tests

### DIFF
--- a/services/csharp/IntegrationTest/docker_compose.yml
+++ b/services/csharp/IntegrationTest/docker_compose.yml
@@ -8,11 +8,15 @@ services:
 
   gateway-internal:
     image: improbable-onlineservices-gateway-internal:test
+    depends_on:
+      - redis
     environment:
       REDIS_CONNECTION_STRING: "redis:6379"
 
   gateway:
     image: improbable-onlineservices-gateway:test
+    depends_on:
+      - redis
     environment:
       REDIS_CONNECTION_STRING: "redis:6379"
       SPATIAL_REFRESH_TOKEN: "${SPATIAL_REFRESH_TOKEN}"
@@ -27,6 +31,8 @@ services:
 
   party:
     image: improbable-onlineservices-party:test
+    depends_on:
+      - redis
     environment:
       REDIS_CONNECTION_STRING: "redis:6379"
       SPATIAL_REFRESH_TOKEN: "${SPATIAL_REFRESH_TOKEN}"


### PR DESCRIPTION
Since everything starts up at the same time, it is likely that the Redis instance might not be up by the time a service tries to connect to it, so they throw an exception and die.
Adding a `depends_on` block to each service in the integ tests should make it wait for Redis before starting, and hopefully stop the flakes.