### PR TITLE
Simplify sample matcher

### DIFF
--- a/services/csharp/SampleMatcher/Matcher.cs
+++ b/services/csharp/SampleMatcher/Matcher.cs
@@ -110,7 +110,7 @@ namespace Improbable.OnlineServices.SampleMatcher
         {
             dpl.Tag.Remove(ReadyTag);
             dpl.Tag.Add(InUseTag);
-            var req = new UpdateDeploymentRequest {Deployment = dpl};
+            var req = new UpdateDeploymentRequest { Deployment = dpl };
             dplClient.UpdateDeployment(req);
         }
     }


### PR DESCRIPTION
Make the sample matcher a little bit simpler and remove some redundant state.