### PR TITLE
Rename in-use tag in sample matcher

### DIFF
--- a/services/csharp/SampleMatcher/Matcher.cs
+++ b/services/csharp/SampleMatcher/Matcher.cs
@@ -14,7 +14,7 @@ namespace Improbable.OnlineServices.SampleMatcher
         private readonly string _project;
         private readonly string _tag;
         private readonly string ReadyTag = "ready"; // This should be the same tag a DeploymentPool looks for.
-        private readonly string InUseTag = "in-use";
+        private readonly string InUseTag = "in_use";
 
         public Matcher()
         {


### PR DESCRIPTION
Hyphens actually aren't allowed in tags; there's a bug on the platform side where the tag names aren't validated on `Update`, which is what we use. Underscores are fine.