### PR TITLE
Adding [r]:srv/bundles perm to svc accounts

### DIFF
--- a/tools/ServiceAccountCLI/Program.cs
+++ b/tools/ServiceAccountCLI/Program.cs
@@ -60,11 +60,10 @@ namespace ServiceAccountCLI
                 Verbs = {projectPermissionVerbs}
             };
 
-            var bundlePermissionsVerb = new RepeatedField<Permission.Types.Verb> {Permission.Types.Verb.Read};
             var bundlePermissions = new Permission
             {
                 Parts = {new RepeatedField<string> {"srv", "bundles"}},
-                Verbs = {bundlePermissionsVerb}
+                Verbs = {new RepeatedField<Permission.Types.Verb> {Permission.Types.Verb.Read}}
             };
 
             var permissions = new RepeatedField<Permission> {projectPermission, bundlePermissions};


### PR DESCRIPTION
Adding the [r]:srv/bundles perm to svc accounts generated with the tool. This makes them able to start deployments when using the Deployment Pool.