### PR TITLE
Check all NotStopped Deployments when finding match

### DIFF
--- a/services/csharp/SampleMatcher/Matcher.cs
+++ b/services/csharp/SampleMatcher/Matcher.cs
@@ -102,8 +102,7 @@ namespace Improbable.OnlineServices.SampleMatcher
                         .NotStoppedDeployments,
                     View = ViewType.Basic
                 })
-                .Where(d => d.Status == Deployment.Types.Status.Running)
-                .FirstOrDefault(d => d.Tag.Contains(tag) && d.Tag.Contains(ReadyTag));
+                .FirstOrDefault(d => d.Status == Deployment.Types.Status.Running && d.Tag.Contains(tag) && d.Tag.Contains(ReadyTag));
         }
 
         private void MarkDeploymentAsInUse(DeploymentServiceClient dplClient, Deployment dpl)


### PR DESCRIPTION
If a project contains a few different deployments and some are not in "Running" or "Stopped" state, it is not guaranteed to have all the "Running" deployments first. This means we need to look at all deployments to find ones with the `match` tag. Moving this logic into the FirstOrDefault call.