### PR TITLE
Catch unexpected errors in Pool iteration

### DIFF
--- a/services/csharp/DeploymentPool/DeploymentPool.cs
+++ b/services/csharp/DeploymentPool/DeploymentPool.cs
@@ -81,7 +81,7 @@ namespace DeploymentPool
                 {
                     // If we repeatedly catch exceptions, back off so we don't contribute to any downstream problems.
                     var retrySeconds = 2 ^ retries;
-                    Log.Logger.Warning("Exception encountered during iteration: Retrying in {s}. Error was {e}", retrySeconds, e);
+                    Log.Logger.Warning("Exception encountered during iteration: Retrying in {retrySeconds}s. Error was {e}", retrySeconds, e);
                     await Task.Delay(TimeSpan.FromSeconds(retrySeconds));
                     retries = Math.Min(retries + 1, 4);
                 }


### PR DESCRIPTION
If the Pool throws an error (Likely to be ListDeployments) then we retry immediately. To avoid spamming a failing endpoint if a service is down, I added exponential backoff up to 16 seconds. This loop also catches any unexpected exceptions that would otherwise crash the pool.