### PR TITLE
Add wait option to integ test suite

### DIFF
--- a/services/csharp/IntegrationTest/test.ps1
+++ b/services/csharp/IntegrationTest/test.ps1
@@ -4,7 +4,8 @@ param (
 	[switch] $test_invite,
 	[switch] $test_matchmaking,
 	[switch] $test_playfab_auth,
-	[switch] $test_all
+	[switch] $test_all,
+	[switch] $wait
 )
 
 $ErrorActionPreference = "stop"
@@ -60,7 +61,7 @@ try {
 	
 	if ($test_matchmaking) {
 		Write-Output "Running tests for the Matchmaking system."
-		dotnet test --filter "MatchmakingSystemShould"
+		& "dotnet.exe" test --filter "MatchmakingSystemShould"
 	}
 	
 	if ($test_party) {
@@ -76,6 +77,10 @@ try {
 	if ($test_playfab_auth) {
 		Write-Output "Running tests for the PlayFab Auth system."
 		& "dotnet.exe" test --filter "PlayFabAuthShould"
+	}
+	if ($wait) {
+		Write-Output "Services started. Waiting for user input before quitting."
+		& "docker-compose.exe" -f docker_compose.yml logs -f
 	}
 } finally {
 	Finish

--- a/services/csharp/IntegrationTest/test.sh
+++ b/services/csharp/IntegrationTest/test.sh
@@ -45,6 +45,9 @@ test_playfab_auth=$?
 was_argument_passed "--test_all"
 test_all=$?
 
+was_argument_passed "--wait"
+wait_after_start=$?
+
 if [ ${test_all} -eq 0 ]; then
     test_party=0
     test_matchmaking=0
@@ -99,4 +102,9 @@ fi
 if [ ${test_playfab_auth} -eq 0 ]; then
   echo "Running tests for PlayFab Auth system."
   dotnet test --filter "PlayFabAuthShould"
+fi
+
+if [ ${wait_after_start} -eq 0 ]; then
+  echo "Services started. Waiting for user input before quitting."
+  docker-compose -f docker_compose.yml logs -f
 fi


### PR DESCRIPTION
Adding an option to stop and view logs during the integration test runs. This is useful to run the tests in the IDE after starting the services.