### PR TITLE
Replace kubectl apply -Rf . in quickstart docs with manual list

### DIFF
--- a/docs/content/get-started/quickstart-4.md
+++ b/docs/content/get-started/quickstart-4.md
@@ -71,7 +71,7 @@ kubectl apply -Rf playfab-auth/
 kubectl apply -Rf sample-matcher/
 ```
 
-This will recursively look through every file in the directory, generate configuration from it and push it to the cluster. You can then check your [Kubernetes Workloads page](https://console.cloud.google.com/kubernetes/workload) and watch as everything goes green. Congratulations - you've deployed successfully.
+These commands will recursively look through every file in the directories, generate configuration from them, and then push them to the cluster. You can then check your [Kubernetes Workloads page](https://console.cloud.google.com/kubernetes/workload) and watch as everything goes green. Congratulations - you've deployed successfully.
 
 ![]({{assetRoot}}img/workloads.png)
 


### PR DESCRIPTION
The current quickstart docs deploy `deployment-pool`, which causes a pair of crashloops due to: 

* Lacking the correct config files for `deployment-pool`
* Having too few nodes in the cluster.

Discussed with Ben earlier and we came to the conclusion that listing these directories manually is probably the least hacky solution, and avoids future issues if other components are added.

Tested locally for syntax errors; applies correctly.