### PR TITLE
Base for analytics instrumentation system

### DIFF
--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -74,14 +74,14 @@ namespace Common.Test
         private bool ExpectedMessage(HttpRequestMessage request)
         {
             var development = AnalyticsEnvironment.Development.ToString().ToLower();
-            
+
             Assert.IsInstanceOf<StringContent>(request.Content);
             if (request.Content is StringContent messageContent)
             {
                 dynamic content = JsonConvert.DeserializeObject(messageContent.ReadAsStringAsync().Result);
 
                 // TODO: Test versioning when it is added
-                Assert.AreEqual(content.eventEnvironment.Value, 
+                Assert.AreEqual(content.eventEnvironment.Value,
                     development);
                 Assert.AreEqual(content.eventIndex.Value, "0");
                 Assert.AreEqual(content.eventSource.Value, SourceVal);
@@ -113,7 +113,7 @@ namespace Common.Test
         public void SendAnalyticEventsToHttpsEndpoint()
         {
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
-            AnalyticsSender.Build(new[] {$"--{EndpointName}", "https://example.com/"},
+            AnalyticsSender.Build(new[] { $"--{EndpointName}", "https://example.com/" },
                     AnalyticsEnvironment.Development, KeyVal, SourceVal, client)
                 .Send(ClassVal, TypeVal, new Dictionary<string, string>
                 {

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -46,7 +46,7 @@ namespace Common.Test
         public void BuildRealAnalyticsSenderIfProvidedWithEndpoint()
         {
             Assert.IsInstanceOf<AnalyticsSender>(AnalyticsSender.Build(
-                new[] {$"--{EndpointName}", "https://example.com/"},
+                new[] { $"--{EndpointName}", "https://example.com/" },
                 AnalyticsEnvironment.Development, ""));
         }
 
@@ -54,7 +54,7 @@ namespace Common.Test
         public void FailToBuildIfHttpIsNotUsedWithoutInsecureEnabled()
         {
             Assert.Throws(typeof(ArgumentException),
-                () => AnalyticsSender.Build(new[] {$"--{EndpointName}", "http://example.com/"},
+                () => AnalyticsSender.Build(new[] { $"--{EndpointName}", "http://example.com/" },
                     AnalyticsEnvironment.Development, ""));
         }
 
@@ -62,14 +62,14 @@ namespace Common.Test
         public void AllowsHttpIfInsecureEndpointsEnabled()
         {
             Assert.IsInstanceOf<AnalyticsSender>(AnalyticsSender.Build(
-                new[] {$"--{EndpointName}", "http://example.com/", $"--{AllowInsecureEndpointName}"},
+                new[] { $"--{EndpointName}", "http://example.com/", $"--{AllowInsecureEndpointName}" },
                 AnalyticsEnvironment.Development, ""));
         }
 
         private bool ExpectedMessage(HttpRequestMessage request)
         {
             Assert.IsInstanceOf<FormUrlEncodedContent>(request.Content);
-            
+
             if (request.Content is FormUrlEncodedContent messageContent)
             {
                 NameValueCollection content = messageContent.ReadAsFormDataAsync().Result;
@@ -81,7 +81,7 @@ namespace Common.Test
                 Assert.AreEqual(content["eventClass"], "test");
                 Assert.AreEqual(content["eventType"], "send");
                 Assert.True(Guid.TryParse(content["sessionId"], out Guid _));
-                
+
                 // Check the timestamp is within 5 seconds of now (i.e. roughly correct)
                 long unixTimestampDelta = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
                                           - long.Parse(content["eventTimestamp"]);
@@ -98,7 +98,7 @@ namespace Common.Test
             // TODO: Update with real category
             Assert.AreEqual(queryCollection["event_category"], "");
             Assert.True(Guid.TryParse(queryCollection["session_id"], out Guid _));
-            
+
             return request.Method == HttpMethod.Post;
         }
 
@@ -106,7 +106,7 @@ namespace Common.Test
         public void SendAnalyticEventsToHttpsEndpoint()
         {
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
-            AnalyticsSender.Build(new[] {$"--{EndpointName}", "https://example.com/"},
+            AnalyticsSender.Build(new[] { $"--{EndpointName}", "https://example.com/" },
                     AnalyticsEnvironment.Development, "fakeKey", "source", client)
                 .Send("test", "send", new Dictionary<string, string>
                 {
@@ -117,7 +117,7 @@ namespace Common.Test
             _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(1),
                 ItExpr.Is<HttpRequestMessage>(req => ExpectedMessage(req)),
                 ItExpr.IsAny<CancellationToken>());
-            
+
         }
     }
 }

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Google.Api;
+using Google.Cloud.Logging.Type;
 using Improbable.OnlineServices.Common.Analytics;
 using Moq;
 using Moq.Protected;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using static Improbable.OnlineServices.Common.Analytics.AnalyticsCommandLineArgs;
 
@@ -64,12 +68,47 @@ namespace Common.Test
                 AnalyticsEnvironment.Development, ""));
         }
 
+        private bool ExpectedMessage(HttpRequestMessage request)
+        {
+            Assert.IsInstanceOf<FormUrlEncodedContent>(request.Content);
+            
+            if (request.Content is FormUrlEncodedContent messageContent)
+            {
+                NameValueCollection content = messageContent.ReadAsFormDataAsync().Result;
+
+                // TODO: Test versioning when it is added
+                Assert.AreEqual(content["eventEnvironment"], "development");
+                Assert.AreEqual(content["eventIndex"], "0");
+                Assert.AreEqual(content["eventSource"], "source");
+                Assert.AreEqual(content["eventClass"], "test");
+                Assert.AreEqual(content["eventType"], "send");
+                Assert.True(Guid.TryParse(content["sessionId"], out Guid _));
+                
+                // Check the timestamp is within 5 seconds of now (i.e. roughly correct)
+                long unixTimestampDelta = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+                                          - long.Parse(content["eventTimestamp"]);
+                Assert.GreaterOrEqual(unixTimestampDelta, 0);
+                Assert.Less(unixTimestampDelta, 5);
+
+                dynamic eventContent = JsonConvert.DeserializeObject(content["eventAttributes"]);
+                Assert.AreEqual(eventContent.dogs.ToString(), "excellent");
+            }
+
+            Assert.AreEqual(request.RequestUri.ParseQueryString()["key"], "fakeKey");
+            Assert.AreEqual(request.RequestUri.ParseQueryString()["analytics_environment"], "development");
+            // TODO: Update with real category
+            Assert.AreEqual(request.RequestUri.ParseQueryString()["event_category"], "");
+            Assert.True(Guid.TryParse(request.RequestUri.ParseQueryString()["session_id"], out Guid _));
+            
+            return request.Method == HttpMethod.Post;
+        }
+
         [Test]
         public void SendAnalyticEventsToHttpsEndpoint()
         {
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
             AnalyticsSender.Build(new[] {$"--{EndpointName}", "https://example.com/"},
-                    AnalyticsEnvironment.Development, "", "", client)
+                    AnalyticsEnvironment.Development, "fakeKey", "source", client)
                 .Send("test", "send", new Dictionary<string, string>
                 {
                     {"dogs", "excellent"}
@@ -77,8 +116,9 @@ namespace Common.Test
 
             // TODO: Verify contents of the message
             _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post),
+                ItExpr.Is<HttpRequestMessage>(req => ExpectedMessage(req)),
                 ItExpr.IsAny<CancellationToken>());
+            
         }
     }
 }

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -5,8 +5,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Google.Api;
-using Google.Cloud.Logging.Type;
 using Improbable.OnlineServices.Common.Analytics;
 using Moq;
 using Moq.Protected;

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Improbable.OnlineServices.Common.Analytics;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using static Improbable.OnlineServices.Common.Analytics.AnalyticsCommandLineArgs;
+
+namespace Common.Test
+{
+    public class AnalyticsShould
+    {
+        private Mock<HttpMessageHandler> _messageHandlerMock;
+
+        [SetUp]
+        public void Setup()
+        {
+            _messageHandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            _messageHandlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                ).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("")
+                }).Verifiable();
+        }
+
+        [Test]
+        public void BuildNullByDefault()
+        {
+            Assert.IsInstanceOf<NullAnalyticsSender>(AnalyticsSender.Build(new string[] { },
+                AnalyticsEnvironment.Development, ""));
+        }
+
+        [Test]
+        public void BuildRealAnalyticsSenderIfProvidedWithEndpoint()
+        {
+            Assert.IsInstanceOf<AnalyticsSender>(AnalyticsSender.Build(
+                new[] {$"--{EndpointName}", "https://example.com/"},
+                AnalyticsEnvironment.Development, ""));
+        }
+
+        [Test]
+        public void FailToBuildIfHttpIsNotUsedWithoutInsecureEnabled()
+        {
+            Assert.Throws(typeof(ArgumentException),
+                () => AnalyticsSender.Build(new[] {$"--{EndpointName}", "http://example.com/"},
+                    AnalyticsEnvironment.Development, ""));
+        }
+
+        [Test]
+        public void AllowsHttpIfInsecureEndpointsEnabled()
+        {
+            Assert.IsInstanceOf<AnalyticsSender>(AnalyticsSender.Build(
+                new[] {$"--{EndpointName}", "http://example.com/", $"--{AllowInsecureEndpointName}"},
+                AnalyticsEnvironment.Development, ""));
+        }
+
+        [Test]
+        public void SendAnalyticEventsToHttpsEndpoint()
+        {
+            HttpClient client = new HttpClient(_messageHandlerMock.Object);
+            AnalyticsSender.Build(new[] {$"--{EndpointName}", "https://example.com/"},
+                    AnalyticsEnvironment.Development, "", "", client)
+                .Send("test", "send", new Dictionary<string, string>
+                {
+                    {"dogs", "excellent"}
+                });
+
+            // TODO: Verify contents of the message
+            _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>());
+        }
+    }
+}

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -94,11 +94,12 @@ namespace Common.Test
                 Assert.AreEqual(eventContent.dogs.ToString(), "excellent");
             }
 
-            Assert.AreEqual(request.RequestUri.ParseQueryString()["key"], "fakeKey");
-            Assert.AreEqual(request.RequestUri.ParseQueryString()["analytics_environment"], "development");
+            var queryCollection = request.RequestUri.ParseQueryString();
+            Assert.AreEqual(queryCollection["key"], "fakeKey");
+            Assert.AreEqual(queryCollection["analytics_environment"], "development");
             // TODO: Update with real category
-            Assert.AreEqual(request.RequestUri.ParseQueryString()["event_category"], "");
-            Assert.True(Guid.TryParse(request.RequestUri.ParseQueryString()["session_id"], out Guid _));
+            Assert.AreEqual(queryCollection["event_category"], "");
+            Assert.True(Guid.TryParse(queryCollection["session_id"], out Guid _));
             
             return request.Method == HttpMethod.Post;
         }

--- a/services/csharp/Common.Test/Common.Test.csproj
+++ b/services/csharp/Common.Test/Common.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <RootNamespace>Improbable.OnlineServices.Common.Test</RootNamespace>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
@@ -9,8 +10,8 @@
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.10.1" />
         <PackageReference Include="nunit" Version="3.11.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
         <PackageReference Include="System.Net.Http.Formatting.Extension" Version="5.2.3" />
     </ItemGroup>
 

--- a/services/csharp/Common.Test/Common.Test.csproj
+++ b/services/csharp/Common.Test/Common.Test.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Moq" Version="4.10.1" />
+        <PackageReference Include="nunit" Version="3.11.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Common\Common.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/services/csharp/Common.Test/Common.Test.csproj
+++ b/services/csharp/Common.Test/Common.Test.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="nunit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="System.Net.Http.Formatting.Extension" Version="5.2.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
+++ b/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
@@ -5,7 +5,7 @@ namespace Improbable.OnlineServices.Common.Analytics
     public class AnalyticsCommandLineArgs
     {
         public const string EndpointName = "analytics.endpoint";
-        public const string AllowInsecureEndpointName = "analytics.allowinsecureendpoint";
+        public const string AllowInsecureEndpointName = "analytics.allow-insecure-endpoint";
 
         [Option(EndpointName, HelpText =
             "Endpoint for analytics to be sent to. If not provided, then analytics are disabled")]

--- a/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
+++ b/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
@@ -1,0 +1,17 @@
+using CommandLine;
+
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    public class AnalyticsCommandLineArgs
+    {
+        public const string EndpointName = "analytics.endpoint";
+        public const string AllowInsecureEndpointName = "analytics.allowinsecureendpoint";
+
+        [Option(EndpointName, HelpText =
+            "Endpoint for analytics to be sent to. If not provided, then analytics are disabled")]
+        public string Endpoint { get; set; }
+
+        [Option(AllowInsecureEndpointName, Default = false, HelpText = "If set, allows http URLs for the endpoint")]
+        public bool AllowInsecureEndpoints { get; set; }
+    }
+}

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Numerics;
+using System.Threading.Tasks;
+using CommandLine;
+using Newtonsoft.Json;
+
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    public enum AnalyticsEnvironment
+    {
+        Testing,
+        Development,
+        Staging,
+        Production,
+        Live,
+    }
+
+    public class AnalyticsSender : IAnalyticsSender
+    {
+        public static IAnalyticsSender Build(string[] args, AnalyticsEnvironment environment,
+            string gcpKey, string eventSource = "server", HttpClient client = null)
+        {
+            IAnalyticsSender sender = new NullAnalyticsSender();
+
+            Parser.Default.ParseArguments<AnalyticsCommandLineArgs>(args)
+                .WithParsed(parsedArgs =>
+                {
+                    if (parsedArgs.Endpoint != null)
+                    {
+                        sender = new AnalyticsSender(parsedArgs, environment, gcpKey, eventSource,
+                            client ?? new HttpClient());
+                    }
+                });
+
+            return sender;
+        }
+
+        private readonly Uri _endpoint;
+        private readonly AnalyticsEnvironment _environment;
+        private readonly string _sessionId = Guid.NewGuid().ToString();
+        private readonly string _gcpKey;
+        private readonly string _eventSource;
+
+        private BigInteger _eventId = 0;
+        private readonly HttpClient _httpClient;
+
+        private AnalyticsSender(AnalyticsCommandLineArgs args, AnalyticsEnvironment environment,
+            string gcpKey, string eventSource, HttpClient httpClient)
+        {
+            _environment = environment;
+            _gcpKey = gcpKey;
+            _eventSource = eventSource;
+            _httpClient = httpClient;
+
+            Console.WriteLine($"Dispatching analytics to {args.Endpoint}");
+
+            _endpoint = new Uri(args.Endpoint);
+            if (_endpoint.Scheme != Uri.UriSchemeHttps && !args.AllowInsecureEndpoints)
+            {
+                throw new ArgumentException(
+                    $"The endpoint provided uses {_endpoint.Scheme}, but only {Uri.UriSchemeHttps} is allowed. "
+                    + $"Enable insecure communication with --{AnalyticsCommandLineArgs.AllowInsecureEndpointName}.");
+            }
+        }
+
+        /// <summary>
+        /// Sends an analytics event to the endpoint.
+        /// </summary>
+        /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
+        /// <param name="eventType">
+        /// A more specific identifier for the event, e.g. `join`
+        /// </param>
+        /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
+        public void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
+        {
+                lock (this)
+                {
+                    _eventId++;
+                    string environment = _environment.ToString().ToLower();
+
+                    var urlParams = new Dictionary<string, string>
+                    {
+                        {"key", _gcpKey},
+                        {"analytics_environment", environment},
+                        {"event_category", ""},
+                        {"session_id", _sessionId}
+                    };
+
+                    // TODO: Can the redundancy in postParams be fixed by amending the pipeline to import the URL
+                    //   params into JSON?
+                    var postParams = new Dictionary<string, string>()
+                    {
+                        {"eventEnvironment", environment},
+                        {"eventIndex", _eventId.ToString()},
+                        {"eventSource", _eventSource},
+                        {"eventClass", eventClass},
+                        {"eventType", eventType},
+                        {"sessionId", _sessionId},
+                        // TODO: Add versioning ability
+                        {"buildVersion", "v0.0.0"},
+                        {"eventTimestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString()},
+                        // TODO: Event attributes
+                        {"eventAttributes", JsonConvert.SerializeObject(eventAttributes)},
+                    };
+
+                    var queryString = new FormUrlEncodedContent(urlParams).ReadAsStringAsync();
+                    queryString.Wait();
+                    UriBuilder builder = new UriBuilder(_endpoint)
+                    {
+                        Query = queryString.Result
+                    };
+
+                    // TODO: Process response to handle failure / verify success
+                    Task<HttpResponseMessage> response
+                        = _httpClient.PostAsync(builder.ToString(), new FormUrlEncodedContent(postParams));
+                    response.Wait();
+                }
+        }
+    }
+}

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -111,7 +111,8 @@ namespace Improbable.OnlineServices.Common.Analytics
             };
 
             // TODO: Process response to handle failure / verify success
-            await _httpClient.PostAsync(builder.ToString(), new FormUrlEncodedContent(postParams));
+            await _httpClient.PostAsync(builder.ToString(),
+                new StringContent(JsonConvert.SerializeObject(postParams)));
         }
 
         private static string DictionaryToQueryString(Dictionary<string, string> urlParams)

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -75,7 +75,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         public async Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
         {
             BigInteger eventId;
-            
+
             lock (this)
             {
                 eventId = _eventId++;

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Numerics;
-using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using CommandLine;
@@ -22,7 +20,7 @@ namespace Improbable.OnlineServices.Common.Analytics
 
     public class AnalyticsSender : IAnalyticsSender
     {
-        public static IAnalyticsSender Build(string[] args, AnalyticsEnvironment environment,
+        public static IAnalyticsSender Build(IEnumerable<string> args, AnalyticsEnvironment environment,
             string gcpKey, string eventSource = "server", HttpClient client = null)
         {
             IAnalyticsSender sender = new NullAnalyticsSender();

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -69,9 +69,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// Sends an analytics event to the endpoint.
         /// </summary>
         /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
-        /// <param name="eventType">
-        /// A more specific identifier for the event, e.g. `join`
-        /// </param>
+        /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
         /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
         public void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
         {

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -4,10 +4,9 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using CommandLine;
-using MemoryStore;
 using Newtonsoft.Json;
-using static System.Web.HttpUtility;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {
@@ -22,6 +21,15 @@ namespace Improbable.OnlineServices.Common.Analytics
 
     public class AnalyticsSender : IAnalyticsSender
     {
+        private readonly Uri _endpoint;
+        private readonly AnalyticsEnvironment _environment;
+        private readonly string _sessionId = Guid.NewGuid().ToString();
+        private readonly string _gcpKey;
+        private readonly string _eventSource;
+        private readonly HttpClient _httpClient;
+
+        private long _eventId;
+
         public static IAnalyticsSender Build(IEnumerable<string> args, AnalyticsEnvironment environment,
             string gcpKey, string eventSource = "server", HttpClient client = null)
         {
@@ -39,15 +47,6 @@ namespace Improbable.OnlineServices.Common.Analytics
 
             return sender;
         }
-
-        private readonly Uri _endpoint;
-        private readonly AnalyticsEnvironment _environment;
-        private readonly string _sessionId = Guid.NewGuid().ToString();
-        private readonly string _gcpKey;
-        private readonly string _eventSource;
-
-        private long _eventId;
-        private readonly HttpClient _httpClient;
 
         private AnalyticsSender(AnalyticsCommandLineArgs args, AnalyticsEnvironment environment,
             string gcpKey, string eventSource, HttpClient httpClient)
@@ -107,7 +106,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         private static string DictionaryToQueryString(Dictionary<string, string> urlParams)
         {
             return string.Join("&", urlParams.Select(
-                p => $"{UrlEncode(p.Key)}={UrlEncode(p.Value)}"
+                p => $"{HttpUtility.UrlEncode(p.Key)}={HttpUtility.UrlEncode(p.Value)}"
             ));
         }
     }

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -92,7 +92,7 @@ namespace Improbable.OnlineServices.Common.Analytics
 
             // TODO: Can the redundancy in postParams be fixed by amending the pipeline to import the URL
             //   params into JSON?
-            var postParams = new Dictionary<string, string>()
+            var postParams = new Dictionary<string, string>
             {
                 {"eventEnvironment", environment},
                 {"eventIndex", eventId.ToString()},
@@ -100,17 +100,15 @@ namespace Improbable.OnlineServices.Common.Analytics
                 {"eventClass", eventClass},
                 {"eventType", eventType},
                 {"sessionId", _sessionId},
-                // TODO: Add versioning ability
+                // TODO: Add versioning ability & resolve matching TODO in relevant unit tests
                 {"buildVersion", "v0.0.0"},
                 {"eventTimestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString()},
                 {"eventAttributes", JsonConvert.SerializeObject(eventAttributes)},
             };
 
-            var queryString = new FormUrlEncodedContent(urlParams).ReadAsStringAsync();
-            queryString.Wait();
             UriBuilder builder = new UriBuilder(_endpoint)
             {
-                Query = queryString.Result
+                Query = new FormUrlEncodedContent(urlParams).ReadAsStringAsync().GetAwaiter().GetResult()
             };
 
             // TODO: Process response to handle failure / verify success

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    public interface IAnalyticsSender
+    {
+        void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
+    }
+}

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {
     public interface IAnalyticsSender
     {
-        void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
+        Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
     }
 }

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -4,8 +4,7 @@ using System.Threading.Tasks;
 namespace Improbable.OnlineServices.Common.Analytics
 {
     /// <summary>
-    /// An interface for analytics senders to correspond to, used to facilitate the NullAnalyticsSender acting
-    ///   as a black hole for analytics.
+    /// An interface for analytics senders, used to facilitate the NullAnalyticsSender as a black hole for analytics.
     /// Normal usage should be through the Build method in AnalyticsSender.
     /// </summary>
     public interface IAnalyticsSender

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -3,8 +3,19 @@ using System.Threading.Tasks;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {
+    /// <summary>
+    /// An interface for analytics senders to correspond to, used to facilitate the NullAnalyticsSender acting
+    ///   as a black hole for analytics.
+    /// Normal usage should be through the Build method in AnalyticsSender.
+    /// </summary>
     public interface IAnalyticsSender
     {
+        /// <summary>
+        /// Dispatch an analytics event to an endpoint, if one has been specified
+        /// </summary>
+        /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
+        /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
+        /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
         Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
     }
 }

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    /// <summary>
+    /// A black hole for analytics messages which does nothing; used as a default implementation for when analytics
+    /// is disabled.
+    /// </summary>
+    public class NullAnalyticsSender : IAnalyticsSender
+    {
+        public void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {
@@ -8,9 +9,9 @@ namespace Improbable.OnlineServices.Common.Analytics
     /// </summary>
     public class NullAnalyticsSender : IAnalyticsSender
     {
-        public void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
+        public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
         {
-            // Do nothing
+            return null;
         }
     }
 }

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -11,7 +11,7 @@ namespace Improbable.OnlineServices.Common.Analytics
     {
         public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
         {
-            return null;
+            return Task.CompletedTask;
         }
     }
 }

--- a/services/csharp/Common/Common.csproj
+++ b/services/csharp/Common/Common.csproj
@@ -14,10 +14,12 @@
     <Copyright>2019 Improbable Worlds Ltd.</Copyright>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.5.0" />
     <PackageReference Include="Grpc.Core" Version="1.19.0" />
     <PackageReference Include="Improbable.SpatialOS.Platform" Version="14.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../MemoryStore/MemoryStore.csproj" />
+    <ProjectReference Include="..\Base.Server\Base.Server.csproj" />
   </ItemGroup>
 </Project>

--- a/services/csharp/Common/Common.csproj
+++ b/services/csharp/Common/Common.csproj
@@ -20,6 +20,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../MemoryStore/MemoryStore.csproj" />
-    <ProjectReference Include="..\Base.Server\Base.Server.csproj" />
   </ItemGroup>
 </Project>

--- a/services/csharp/Common/Common.csproj
+++ b/services/csharp/Common/Common.csproj
@@ -14,7 +14,7 @@
     <Copyright>2019 Improbable Worlds Ltd.</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.5.0" />
+    <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Grpc.Core" Version="1.19.0" />
     <PackageReference Include="Improbable.SpatialOS.Platform" Version="14.0.0" />
   </ItemGroup>

--- a/services/csharp/metagame-services.sln
+++ b/services/csharp/metagame-services.sln
@@ -45,6 +45,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleClient", "SampleClien
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeploymentPool.Test", "DeploymentPool.Test\DeploymentPool.Test.csproj", "{9D436F1A-2352-4213-8316-9B36D7E5F1F7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Test", "Common.Test\Common.Test.csproj", "{0F4544CB-65E2-4A87-B753-777E964C583E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -310,5 +312,17 @@ Global
 		{9D436F1A-2352-4213-8316-9B36D7E5F1F7}.Release|x64.Build.0 = Release|Any CPU
 		{9D436F1A-2352-4213-8316-9B36D7E5F1F7}.Release|x86.ActiveCfg = Release|Any CPU
 		{9D436F1A-2352-4213-8316-9B36D7E5F1F7}.Release|x86.Build.0 = Release|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Debug|x64.Build.0 = Debug|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Debug|x86.Build.0 = Debug|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Release|x64.ActiveCfg = Release|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Release|x64.Build.0 = Release|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Release|x86.ActiveCfg = Release|Any CPU
+		{0F4544CB-65E2-4A87-B753-777E964C583E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR adds the foundations for instrumenting this repo for the reporting of analytics data.

The current state contains some basic classes for achieving this, with the main deficiencies being:
- Currently lacks a method of injecting the GCP key.
- Event categories are always empty.
- Messages are not batched, but instead all sent individually.

I intend to fix these in the next PR to avoid bloating this one too much.