### PR TITLE
Analytics config

### DIFF
--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -110,7 +110,7 @@ namespace Improbable.OnlineServices.Common.Test
             Assert.AreEqual(KeyVal, queryCollection["key"]);
             Assert.AreEqual(development, queryCollection["analytics_environment"]);
             Assert.AreEqual(AnalyticsSender.DefaultEventCategory, queryCollection["event_category"]);
-            Assert.True(Guid.TryParse(queryCollection["session_id"], out Guid _));
+            Assert.True(Guid.TryParse((string) queryCollection["session_id"], out Guid _));
 
             return request.Method == HttpMethod.Post;
         }

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -16,9 +16,11 @@ namespace Improbable.OnlineServices.Common.Test
     public class AnalyticsShould
     {
         private Mock<HttpMessageHandler> _messageHandlerMock;
-        private string _gcpKey = "ABCDEF";
-        private string _eventSource = "event_source";
-        private AnalyticsEnvironment _devEnv = AnalyticsEnvironment.Development;
+        private const string SourceVal = "event_source_value";
+        private const string ClassVal = "event_class_value";
+        private const string TypeVal = "event_type_value";
+        private const string KeyVal = "gcp_key_value";
+        private const AnalyticsEnvironment DevEnv = AnalyticsEnvironment.Development;
 
         [SetUp]
         public void Setup()
@@ -41,7 +43,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void BuildNullByDefault()
         {
             Assert.IsInstanceOf<NullAnalyticsSender>(
-                new AnalyticsSenderBuilder(_devEnv, _gcpKey, _eventSource).Build()
+                new AnalyticsSenderBuilder(DevEnv, KeyVal, SourceVal).Build()
             );
         }
 
@@ -49,7 +51,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void BuildRealAnalyticsSenderIfProvidedWithEndpoint()
         {
             Assert.IsInstanceOf<AnalyticsSender>(
-                new AnalyticsSenderBuilder(_devEnv, _gcpKey, _eventSource)
+                new AnalyticsSenderBuilder(DevEnv, KeyVal, SourceVal)
                     .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                     .Build()
             );
@@ -59,7 +61,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void FailToBuildIfHttpIsNotUsedWithoutInsecureEnabled()
         {
             ArgumentException ex = Assert.Throws<ArgumentException>(
-                () => new AnalyticsSenderBuilder(_devEnv, _gcpKey, _eventSource)
+                () => new AnalyticsSenderBuilder(DevEnv, KeyVal, SourceVal)
                     .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/").Build()
             );
 
@@ -70,17 +72,12 @@ namespace Improbable.OnlineServices.Common.Test
         public void AllowsHttpIfInsecureEndpointsEnabled()
         {
             Assert.IsInstanceOf<AnalyticsSender>(
-                new AnalyticsSenderBuilder(_devEnv, _gcpKey, _eventSource)
+                new AnalyticsSenderBuilder(DevEnv, KeyVal, SourceVal)
                     .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/",
                         $"--{AnalyticsCommandLineArgs.AllowInsecureEndpointName}")
                     .Build()
             );
         }
-
-        private const string SourceVal = "event_source_value";
-        private const string ClassVal = "event_class_value";
-        private const string TypeVal = "event_type_value";
-        private const string KeyVal = "fakeKey";
 
         private bool ExpectedMessage(HttpRequestMessage request)
         {
@@ -122,7 +119,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void SendAnalyticEventsToHttpsEndpoint()
         {
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
-            new AnalyticsSenderBuilder(_devEnv, _gcpKey, _eventSource)
+            new AnalyticsSenderBuilder(DevEnv, KeyVal, SourceVal)
                 .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                 .With(client)
                 .Build()
@@ -140,7 +137,8 @@ namespace Improbable.OnlineServices.Common.Test
         public void FallBackToDefaultConfigurationGracefully()
         {
             AnalyticsConfig config = new AnalyticsConfig("");
-            Assert.AreEqual(config.GetCategory("c", "t"), AnalyticsSender.DefaultEventCategory);
+            Assert.AreEqual(config.GetCategory("c", "t"), 
+                AnalyticsSender.DefaultEventCategory);
             Assert.True(config.IsEnabled("c", "t"));
         }
 

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -33,30 +33,37 @@ namespace Improbable.OnlineServices.Common.Test
                     Content = new StringContent("")
                 }).Verifiable();
         }
-        
+
         private AnalyticsConfig _emptyConfig = new AnalyticsConfig("");
 
         [Test]
         public void BuildNullByDefault()
         {
-            Assert.IsInstanceOf<NullAnalyticsSender>(AnalyticsSender.Build(new string[] { },
-                AnalyticsEnvironment.Development, _emptyConfig, ""));
+            Assert.IsInstanceOf<NullAnalyticsSender>(AnalyticsSender.Build(
+                    new string[] { }, AnalyticsEnvironment.Development, _emptyConfig, ""
+                )
+            );
         }
 
         [Test]
         public void BuildRealAnalyticsSenderIfProvidedWithEndpoint()
         {
             Assert.IsInstanceOf<AnalyticsSender>(AnalyticsSender.Build(
-                new[] {$"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/"},
-                AnalyticsEnvironment.Development, _emptyConfig, ""));
+                    new[] {$"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/"},
+                    AnalyticsEnvironment.Development, _emptyConfig, ""
+                )
+            );
         }
 
         [Test]
         public void FailToBuildIfHttpIsNotUsedWithoutInsecureEnabled()
         {
             ArgumentException ex = Assert.Throws<ArgumentException>(
-                () => AnalyticsSender.Build(new[] {$"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/"},
-                    AnalyticsEnvironment.Development, _emptyConfig, ""));
+                () => AnalyticsSender.Build(
+                    new[] {$"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/"},
+                    AnalyticsEnvironment.Development, _emptyConfig, ""
+                )
+            );
 
             Assert.That(ex.Message, Contains.Substring("uses http, but only https is allowed"));
         }
@@ -64,10 +71,16 @@ namespace Improbable.OnlineServices.Common.Test
         [Test]
         public void AllowsHttpIfInsecureEndpointsEnabled()
         {
-            Assert.IsInstanceOf<AnalyticsSender>(AnalyticsSender.Build(
-                new[] {$"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/",
-                    $"--{AnalyticsCommandLineArgs.AllowInsecureEndpointName}"},
-                AnalyticsEnvironment.Development, _emptyConfig, ""));
+            Assert.IsInstanceOf<AnalyticsSender>(
+                AnalyticsSender.Build(
+                    new[]
+                    {
+                        $"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/",
+                        $"--{AnalyticsCommandLineArgs.AllowInsecureEndpointName}"
+                    },
+                    AnalyticsEnvironment.Development, _emptyConfig, ""
+                )
+            );
         }
 
         private const string SourceVal = "event_source_value";
@@ -85,12 +98,11 @@ namespace Improbable.OnlineServices.Common.Test
                 dynamic content = JsonConvert.DeserializeObject(messageContent.ReadAsStringAsync().Result);
 
                 // TODO: Test versioning when it is added
-                Assert.AreEqual(content.eventEnvironment.Value,
-                    development);
-                Assert.AreEqual(content.eventIndex.Value, "0");
-                Assert.AreEqual(content.eventSource.Value, SourceVal);
-                Assert.AreEqual(content.eventClass.Value, ClassVal);
-                Assert.AreEqual(content.eventType.Value, TypeVal);
+                Assert.AreEqual(development, content.eventEnvironment.Value);
+                Assert.AreEqual("0", content.eventIndex.Value);
+                Assert.AreEqual(SourceVal, content.eventSource.Value);
+                Assert.AreEqual(ClassVal, content.eventClass.Value);
+                Assert.AreEqual(TypeVal, content.eventType.Value);
                 Assert.True(Guid.TryParse(content.sessionId.Value, out Guid _));
 
                 // Check the timestamp is within 5 seconds of now (i.e. roughly correct)
@@ -104,10 +116,10 @@ namespace Improbable.OnlineServices.Common.Test
             }
 
             var queryCollection = request.RequestUri.ParseQueryString();
-            Assert.AreEqual(queryCollection["key"], KeyVal);
-            Assert.AreEqual(queryCollection["analytics_environment"], development);
+            Assert.AreEqual(KeyVal, queryCollection["key"]);
+            Assert.AreEqual(development, queryCollection["analytics_environment"]);
             // TODO: Update with real category
-            Assert.AreEqual(queryCollection["event_category"], "");
+            Assert.AreEqual(AnalyticsSender.DefaultEventCategory, queryCollection["event_category"]);
             Assert.True(Guid.TryParse(queryCollection["session_id"], out Guid _));
 
             return request.Method == HttpMethod.Post;
@@ -150,28 +162,28 @@ namespace Improbable.OnlineServices.Common.Test
   'c':
     category: 'function-3'
 ";
-        
+
         [Test]
         public void HandleConfigPrecedenceRulesCorrectly()
         {
             AnalyticsConfig config = new AnalyticsConfig(_configString);
-            
+
             // d.e should route to *.* as there is no match
             Assert.False(config.IsEnabled("d", "e"));
             Assert.AreEqual(AnalyticsSender.DefaultEventCategory, config.GetCategory("d", "e"));
-            
+
             // d.a should route to *.a as there is not a better match
             Assert.True(config.IsEnabled("d", "a"));
             Assert.AreEqual("function", config.GetCategory("d", "a"));
-            
+
             // b.d should route to b.* as there is not a better match
             Assert.True(config.IsEnabled("b", "d"));
             Assert.AreEqual("function-2", config.GetCategory("b", "d"));
-            
+
             // b.a should route to b.* as a match on class is preferred on a match on type (i.e. b.* > *.a)
             Assert.True(config.IsEnabled("b", "a"));
             Assert.AreEqual("function-2", config.GetCategory("b", "a"));
-            
+
             // b.c should route to b.c as it is an exact match
             Assert.True(config.IsEnabled("b", "c"));
             Assert.AreEqual("function-3", config.GetCategory("b", "c"));

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -49,7 +49,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void BuildRealAnalyticsSenderIfProvidedWithEndpoint()
         {
             Assert.IsInstanceOf<AnalyticsSender>(AnalyticsSender.Build(
-                    new[] {$"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/"},
+                    new[] { $"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/" },
                     AnalyticsEnvironment.Development, _emptyConfig, ""
                 )
             );
@@ -60,7 +60,7 @@ namespace Improbable.OnlineServices.Common.Test
         {
             ArgumentException ex = Assert.Throws<ArgumentException>(
                 () => AnalyticsSender.Build(
-                    new[] {$"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/"},
+                    new[] { $"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/" },
                     AnalyticsEnvironment.Development, _emptyConfig, ""
                 )
             );
@@ -129,7 +129,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void SendAnalyticEventsToHttpsEndpoint()
         {
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
-            AnalyticsSender.Build(new[] {$"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/"},
+            AnalyticsSender.Build(new[] { $"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/" },
                     AnalyticsEnvironment.Development, _emptyConfig, KeyVal, SourceVal, client)
                 .Send(ClassVal, TypeVal, new Dictionary<string, string>
                 {

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -137,7 +137,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void FallBackToDefaultConfigurationGracefully()
         {
             AnalyticsConfig config = new AnalyticsConfig("");
-            Assert.AreEqual(config.GetCategory("c", "t"), 
+            Assert.AreEqual(config.GetCategory("c", "t"),
                 AnalyticsSender.DefaultEventCategory);
             Assert.True(config.IsEnabled("c", "t"));
         }

--- a/services/csharp/Common.Test/Common.Test.csproj
+++ b/services/csharp/Common.Test/Common.Test.csproj
@@ -9,10 +9,10 @@
 
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.10.1" />
-        <PackageReference Include="nunit" Version="3.11.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-        <PackageReference Include="System.Net.Http.Formatting.Extension" Version="5.2.3" />
+        <PackageReference Include="NUnit" Version="3.10.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+        <PackageReference Include="Wdc.System.Net.Http.Formatting.NetStandard" Version="1.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using CommandLine;
+using Improbable.OnlineServices.Common.Analytics.Config;
+
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    public class AnalyticsSenderBuilder
+    {
+        private readonly string _gcpKey;
+        private readonly string _eventSource;
+        private Uri _endpoint;
+        private AnalyticsConfig _config;
+        private readonly AnalyticsEnvironment _environment;
+        private HttpClient _httpClient = new HttpClient();
+
+        private readonly string _insecureProtocolExceptionMessage
+            = $"The endpoint provided uses {0}, but only {Uri.UriSchemeHttps} is allowed." +
+              $"Enable insecure communication with --{AnalyticsCommandLineArgs.AllowInsecureEndpointName}.";
+
+        public AnalyticsSenderBuilder(AnalyticsEnvironment environment, string gcpKey, string eventSource)
+        {
+            _environment = environment;
+            _gcpKey = gcpKey;
+            _eventSource = eventSource;
+        }
+
+        public IAnalyticsSender Build()
+        {
+            _config = _config ?? new AnalyticsConfig();
+
+            if (_endpoint == null)
+            {
+                return new AnalyticsSender(_endpoint, _config, _environment, _gcpKey, _eventSource, _httpClient);
+            }
+
+            return new NullAnalyticsSender();
+        }
+
+        public AnalyticsSenderBuilder With(HttpClient client)
+        {
+            _httpClient = client;
+            return this;
+        }
+
+        public AnalyticsSenderBuilder With(AnalyticsConfig config)
+        {
+            _config = config;
+            return this;
+        }
+
+        public AnalyticsSenderBuilder WithCommandLineArgs(params string[] args)
+        {
+            return WithCommandLineArgs(args.ToList());
+        }
+
+        public AnalyticsSenderBuilder WithCommandLineArgs(IEnumerable<string> args)
+        {
+            Parser.Default.ParseArguments<AnalyticsCommandLineArgs>(args)
+                .WithParsed(async parsedArgs =>
+                {
+                    if (!string.IsNullOrEmpty(parsedArgs.ConfigPath))
+                    {
+                        _config = await AnalyticsConfig.FromFile(parsedArgs.ConfigPath);
+                    }
+
+                    if (!string.IsNullOrEmpty(parsedArgs.Endpoint))
+                    {
+                        _endpoint = new Uri(parsedArgs.Endpoint);
+
+                        if (_endpoint.Scheme != Uri.UriSchemeHttps)
+                        {
+                            throw new ArgumentException(
+                                string.Format(_insecureProtocolExceptionMessage, _endpoint.Scheme));
+                        }
+                    }
+                });
+            return this;
+        }
+    }
+}

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -65,13 +65,12 @@ namespace Improbable.OnlineServices.Common.Analytics
 
         public AnalyticsSenderBuilder WithCommandLineArgs(IEnumerable<string> args)
         {
-            Uri endpoint;
             Parser.Default.ParseArguments<AnalyticsCommandLineArgs>(args)
                 .WithParsed(async parsedArgs =>
                 {
                     if (!string.IsNullOrEmpty(parsedArgs.ConfigPath))
                     {
-                        _config = await AnalyticsConfig.FromFile(parsedArgs.ConfigPath);
+                        _config = AnalyticsConfig.FromFile(parsedArgs.ConfigPath);
                     }
 
                     if (!string.IsNullOrEmpty(parsedArgs.Endpoint))

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -9,15 +9,16 @@ namespace Improbable.OnlineServices.Common.Analytics
 {
     public class AnalyticsSenderBuilder
     {
+        private readonly AnalyticsEnvironment _environment;
         private readonly string _gcpKey;
         private readonly string _eventSource;
-        private Uri _endpoint;
         private AnalyticsConfig _config;
-        private readonly AnalyticsEnvironment _environment;
+        private bool _allowUnsafeEndpoints;
         private HttpClient _httpClient = new HttpClient();
+        private Uri _endpoint;
 
         private readonly string _insecureProtocolExceptionMessage
-            = $"The endpoint provided uses {0}, but only {Uri.UriSchemeHttps} is allowed." +
+            = $"The endpoint provided uses {{0}}, but only {Uri.UriSchemeHttps} is allowed. " +
               $"Enable insecure communication with --{AnalyticsCommandLineArgs.AllowInsecureEndpointName}.";
 
         public AnalyticsSenderBuilder(AnalyticsEnvironment environment, string gcpKey, string eventSource)
@@ -31,8 +32,14 @@ namespace Improbable.OnlineServices.Common.Analytics
         {
             _config = _config ?? new AnalyticsConfig();
 
-            if (_endpoint == null)
+            if (_endpoint != null)
             {
+                if (_endpoint.Scheme != Uri.UriSchemeHttps && !_allowUnsafeEndpoints)
+                {
+                    throw new ArgumentException(
+                        string.Format(_insecureProtocolExceptionMessage, _endpoint.Scheme));
+                }
+
                 return new AnalyticsSender(_endpoint, _config, _environment, _gcpKey, _eventSource, _httpClient);
             }
 
@@ -58,6 +65,7 @@ namespace Improbable.OnlineServices.Common.Analytics
 
         public AnalyticsSenderBuilder WithCommandLineArgs(IEnumerable<string> args)
         {
+            Uri endpoint;
             Parser.Default.ParseArguments<AnalyticsCommandLineArgs>(args)
                 .WithParsed(async parsedArgs =>
                 {
@@ -69,13 +77,9 @@ namespace Improbable.OnlineServices.Common.Analytics
                     if (!string.IsNullOrEmpty(parsedArgs.Endpoint))
                     {
                         _endpoint = new Uri(parsedArgs.Endpoint);
-
-                        if (_endpoint.Scheme != Uri.UriSchemeHttps)
-                        {
-                            throw new ArgumentException(
-                                string.Format(_insecureProtocolExceptionMessage, _endpoint.Scheme));
-                        }
                     }
+
+                    _allowUnsafeEndpoints = parsedArgs.AllowInsecureEndpoints;
                 });
             return this;
         }

--- a/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
+++ b/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
@@ -1,5 +1,4 @@
 using CommandLine;
-using Improbable.OnlineServices.DataModel.Party;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {

--- a/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
+++ b/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
@@ -1,4 +1,5 @@
 using CommandLine;
+using Improbable.OnlineServices.DataModel.Party;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {
@@ -6,6 +7,7 @@ namespace Improbable.OnlineServices.Common.Analytics
     {
         public const string EndpointName = "analytics.endpoint";
         public const string AllowInsecureEndpointName = "analytics.allow-insecure-endpoint";
+        public const string ConfigPathName = "analytics.config-file-path";
 
         [Option(EndpointName, HelpText =
             "Endpoint for analytics to be sent to. If not provided, then analytics are disabled")]
@@ -13,5 +15,10 @@ namespace Improbable.OnlineServices.Common.Analytics
 
         [Option(AllowInsecureEndpointName, Default = false, HelpText = "If set, allows http URLs for the endpoint")]
         public bool AllowInsecureEndpoints { get; set; }
+
+        [Option(ConfigPathName, HelpText =
+            "Set the path for the analytics configuration file. If not set, default values " +
+            "are assumed for all analytics events.")]
+        public string ConfigPath { get; set; }
     }
 }

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -66,7 +66,7 @@ namespace Improbable.OnlineServices.Common.Analytics
                 { "eventType", eventType },
                 { "sessionId", _sessionId },
                 // TODO: Add versioning ability & resolve matching TODO in relevant unit tests
-                { "buildVersion", "v0.0.0" },
+                { "buildVersion", "0.0.0" },
                 { "eventTimestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString() },
                 { "eventAttributes", JsonConvert.SerializeObject(eventAttributes) },
             };

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -6,12 +6,8 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using CommandLine;
-using CSharpx;
 using Improbable.OnlineServices.Common.Analytics.Config;
 using Newtonsoft.Json;
-
-[assembly: InternalsVisibleTo("Common.Test")]
 
 namespace Improbable.OnlineServices.Common.Analytics
 {

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -25,7 +25,7 @@ namespace Improbable.OnlineServices.Common.Analytics
     public class AnalyticsSender : IAnalyticsSender
     {
         internal const string DefaultEventCategory = "cold";
-        
+
         private readonly Uri _endpoint;
         private readonly AnalyticsConfig _config;
         private readonly AnalyticsEnvironment _environment;
@@ -41,7 +41,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         {
             return Build(args, environment, await AnalyticsConfig.FromFile(configPath), gcpKey, eventSource, client);
         }
-        
+
         public static IAnalyticsSender Build(IEnumerable<string> args, AnalyticsEnvironment environment,
             AnalyticsConfig config, string gcpKey, string eventSource = "server", HttpClient client = null)
         {

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -27,6 +27,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         internal const string DefaultEventCategory = "cold";
         
         private readonly Uri _endpoint;
+        private readonly AnalyticsConfig _config;
         private readonly AnalyticsEnvironment _environment;
         private readonly string _sessionId = Guid.NewGuid().ToString();
         private readonly string _gcpKey;
@@ -51,7 +52,7 @@ namespace Improbable.OnlineServices.Common.Analytics
                 {
                     if (parsedArgs.Endpoint != null)
                     {
-                        sender = new AnalyticsSender(parsedArgs, environment, gcpKey, eventSource,
+                        sender = new AnalyticsSender(parsedArgs, config, environment, gcpKey, eventSource,
                             client ?? new HttpClient());
                     }
                 });
@@ -59,9 +60,10 @@ namespace Improbable.OnlineServices.Common.Analytics
             return sender;
         }
 
-        private AnalyticsSender(AnalyticsCommandLineArgs args, AnalyticsEnvironment environment,
+        private AnalyticsSender(AnalyticsCommandLineArgs args, AnalyticsConfig config, AnalyticsEnvironment environment,
             string gcpKey, string eventSource, HttpClient httpClient)
         {
+            _config = config;
             _environment = environment;
             _gcpKey = gcpKey;
             _eventSource = eventSource;
@@ -104,7 +106,7 @@ namespace Improbable.OnlineServices.Common.Analytics
                 {
                     {"key", _gcpKey},
                     {"analytics_environment", environment},
-                    {"event_category", ""},
+                    {"event_category", _config.GetCategory(eventClass, eventType)},
                     {"session_id", _sessionId}
                 })
             };

--- a/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
+++ b/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
@@ -24,9 +24,9 @@ namespace Improbable.OnlineServices.Common.Analytics.Config
             public bool Disabled { get; set; } = false;
         }
 
-        public static async Task<AnalyticsConfig> FromFile(string filePath)
+        public static AnalyticsConfig FromFile(string filePath)
         {
-            return new AnalyticsConfig(await File.ReadAllTextAsync(filePath));
+            return new AnalyticsConfig(File.ReadAllText(filePath));
         }
 
         // Type defined at head of file

--- a/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
+++ b/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
@@ -30,8 +30,13 @@ namespace Improbable.OnlineServices.Common.Analytics.Config
         }
 
         // Type defined at head of file
-        private readonly EntriesList _entries;
         private const string Wildcard = "*";
+        private readonly EntriesList _entries;
+
+        public AnalyticsConfig()
+        {
+            _entries = new EntriesList();
+        }
 
         public AnalyticsConfig(string contents)
         {

--- a/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
+++ b/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
@@ -43,14 +43,8 @@ namespace Improbable.OnlineServices.Common.Analytics.Config
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(new CamelCaseNamingConvention())
                 .Build();
-            try
-            {
-                _entries = deserializer.Deserialize<EntriesList>(contents) ?? new EntriesList();
-            }
-            catch (YamlException e)
-            {
-                throw new ArgumentException("Invalid YAML was provided", e);
-            }
+            
+            _entries = deserializer.Deserialize<EntriesList>(contents) ?? new EntriesList();
         }
 
         public bool IsEnabled(string eventClass, string eventType) => !GetEntry(eventClass, eventType).Disabled;

--- a/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
+++ b/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using EntriesList = System.Collections.Generic.Dictionary<string,
+    System.Collections.Generic.Dictionary<string,
+        Improbable.OnlineServices.Common.Analytics.Config.AnalyticsConfig.AnalyticsConfigEntry>>;
+
+namespace Improbable.OnlineServices.Common.Analytics.Config
+{
+    /// <summary>
+    /// Given an analytics configuration string, allows querying to determine e.g. event category category and whether
+    ///   or not given event types are enabled.
+    /// </summary>
+    public class AnalyticsConfig
+    {
+        internal class AnalyticsConfigEntry
+        {
+            internal static readonly AnalyticsConfigEntry DefaultEntry = new AnalyticsConfigEntry();
+
+            public string Category { get; set; } = AnalyticsSender.DefaultEventCategory;
+            public bool Disabled { get; set; } = false;
+        }
+
+        public static async Task<AnalyticsConfig> FromFile(string filePath)
+        {
+            return new AnalyticsConfig(await File.ReadAllTextAsync(filePath));
+        }
+
+        // Type defined at head of file
+        private readonly EntriesList _entries;
+        private const string Wildcard = "*";
+
+        public AnalyticsConfig(string contents)
+        {
+            var deserializer = new DeserializerBuilder()
+                .WithNamingConvention(new CamelCaseNamingConvention())
+                .Build();
+            try
+            {
+                _entries = deserializer.Deserialize<EntriesList>(contents) ?? new EntriesList();
+            }
+            catch (YamlException e)
+            {
+                throw new ArgumentException("Invalid YAML was provided", e);
+            }
+        }
+
+        public bool IsEnabled(string eventClass, string eventType) => !GetEntry(eventClass, eventType).Disabled;
+        public string GetCategory(string eventClass, string eventType) => GetEntry(eventClass, eventType).Category;
+
+        /// <summary>
+        /// Gets the most specific entry possible for a given event class/type pair.
+        /// The priority is to match an exact event class, then an exact event type, so in the case where it can choose
+        ///   a wildcard class and a specific type _or_ a specific class and a wildcard type, it will opt for the latter.
+        /// </summary>
+        private AnalyticsConfigEntry GetEntry(string eventClass, string eventType)
+        {
+            if (_entries.ContainsKey(eventClass))
+            {
+                if (_entries[eventClass].ContainsKey(eventType))
+                {
+                    return _entries[eventClass][eventType];
+                }
+                else if (_entries[eventClass].ContainsKey(Wildcard))
+                {
+                    return _entries[eventClass][Wildcard];
+                }
+            }
+
+            if (_entries.ContainsKey(Wildcard))
+            {
+                if (_entries[Wildcard].ContainsKey(eventType))
+                {
+                    return _entries[Wildcard][eventType];
+                }
+                else if (_entries[Wildcard].ContainsKey(Wildcard))
+                {
+                    return _entries[Wildcard][Wildcard];
+                }
+            }
+
+            return AnalyticsConfigEntry.DefaultEntry;
+        }
+    }
+}

--- a/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
+++ b/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
@@ -43,7 +43,7 @@ namespace Improbable.OnlineServices.Common.Analytics.Config
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(new CamelCaseNamingConvention())
                 .Build();
-            
+
             _entries = deserializer.Deserialize<EntriesList>(contents) ?? new EntriesList();
         }
 

--- a/services/csharp/Common/Common.csproj
+++ b/services/csharp/Common/Common.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Grpc.Core" Version="1.19.0" />
     <PackageReference Include="Improbable.SpatialOS.Platform" Version="14.0.0" />
+    <PackageReference Include="YamlDotNet" Version="6.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../MemoryStore/MemoryStore.csproj" />


### PR DESCRIPTION
This PR adds analytics configuration file loading which allows event categories to be defined through a YAML file, as well as offering the ability to selectively disable events. There are other things we may want to add in future (such as reporting frequency, batch queue size, etc.) but these should be trivial to add at a later point.

Config files look like such:

```yaml
"party":
  "join":
    category: "function"

"user":
  "leave_party":
    category: "cold"
  "enter_party":
    disabled: true
```

I have some rough documentation for how this file operates, but I'm still working on how everything should fit together so I'd prefer to include that with the first PR that actually adds any instrumentation since it will have been finalised by then.

I've also made some improvements to the testing file since to amend mixing up the actual / expected parameter order.

In addition, I've gotten rid of the static `Build` method in `AnalyticsSender` and created a dedicated `Builder` class since I had ended up with a horrible mess of different constructors, with arguments almost exclusively to facilitate the test suite injecting a HttpClient.