### PR TITLE
Add batching features to the AnalyticsSender

### DIFF
--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -41,8 +41,6 @@ namespace Improbable.OnlineServices.Common.Test
                 }).Verifiable();
         }
 
-        private AnalyticsConfig _emptyConfig = new AnalyticsConfig("");
-
         [Test]
         public void BuildNullByDefault()
         {

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -54,7 +54,7 @@ namespace Improbable.OnlineServices.Common.Test
         {
             Assert.IsInstanceOf<AnalyticsSender>(
                 new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
-                    .WithCommandLineArgs( $"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/" )
+                    .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                     .Build()
             );
         }
@@ -65,7 +65,7 @@ namespace Improbable.OnlineServices.Common.Test
             ArgumentException ex = Assert.Throws<ArgumentException>(
                 () =>
                     new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
-                        .WithCommandLineArgs( $"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/" )
+                        .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/")
                         .Build()
             );
 
@@ -126,7 +126,7 @@ namespace Improbable.OnlineServices.Common.Test
         {
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
             new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
-                .WithCommandLineArgs( $"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/" )
+                .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                 .WithMaxQueueSize(1)
                 .With(client)
                 .Build()
@@ -202,7 +202,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void FallBackToDefaultConfigurationGracefully()
         {
             AnalyticsConfig config = new AnalyticsConfig("");
-            Assert.AreEqual(config.GetCategory("c", "t"), 
+            Assert.AreEqual(config.GetCategory("c", "t"),
                 DefaultEventCategory);
             Assert.True(config.IsEnabled("c", "t"));
         }

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -27,7 +27,7 @@ namespace Improbable.OnlineServices.Common.Test
         [SetUp]
         public void Setup()
         {
-            _messageHandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            _messageHandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Loose);
             _messageHandlerMock
                 .Protected()
                 .Setup<Task<HttpResponseMessage>>(

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -40,6 +40,8 @@ namespace Improbable.OnlineServices.Common.Test
                     Content = new StringContent("")
                 }).Verifiable();
         }
+        
+        private AnalyticsConfig _emptyConfig = new AnalyticsConfig("");
 
         [Test]
         public void BuildNullByDefault()

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -138,7 +138,7 @@ namespace Improbable.OnlineServices.Common.Test
                 ItExpr.Is<HttpRequestMessage>(req => SendAnalyticEventsToHttpsEndpointExpectedMessage(req)),
                 ItExpr.IsAny<CancellationToken>());
         }
-        
+
         [Test]
         public async Task DispatchAnalyticsEventsForSameUriTogether()
         {
@@ -148,7 +148,7 @@ namespace Improbable.OnlineServices.Common.Test
                 .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                 .With(client)
                 .Build();
-            
+
             await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>());
             await sender.Send("class-val-2", "type-val-2", new Dictionary<string, string>());
             await sender.Send("class-val-3", "type-val-3", new Dictionary<string, string>());
@@ -157,7 +157,7 @@ namespace Improbable.OnlineServices.Common.Test
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>());
         }
-        
+
         [Test]
         public async Task DispatchAnalyticsEventsAfterSomeTime()
         {
@@ -168,7 +168,7 @@ namespace Improbable.OnlineServices.Common.Test
                 .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                 .With(client)
                 .Build();
-            
+
             await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>());
             await sender.Send("class-val-2", "type-val-2", new Dictionary<string, string>());
             await Task.Delay(10);
@@ -177,7 +177,7 @@ namespace Improbable.OnlineServices.Common.Test
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>());
         }
-        
+
         [Test]
         public async Task NotDispatchAnalyticsEventsWithoutTimeOrQueueSize()
         {
@@ -188,10 +188,10 @@ namespace Improbable.OnlineServices.Common.Test
                 .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                 .With(client)
                 .Build();
-            
+
             await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>());
             await sender.Send("class-val-2", "type-val-2", new Dictionary<string, string>());
-            
+
             _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(0),
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>());

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -143,7 +143,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void FallBackToDefaultConfigurationGracefully()
         {
             AnalyticsConfig config = new AnalyticsConfig("");
-            Assert.AreEqual(config.GetCategory("c", "t"),
+            Assert.AreEqual(config.GetCategory("c", "t"), 
                 DefaultEventCategory);
             Assert.True(config.IsEnabled("c", "t"));
         }

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -171,7 +171,7 @@ namespace Improbable.OnlineServices.Common.Test
 
             await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>());
             await sender.Send("class-val-2", "type-val-2", new Dictionary<string, string>());
-            await Task.Delay(10);
+            await Task.Delay(20);
 
             _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(1),
                 ItExpr.IsAny<HttpRequestMessage>(),

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -164,7 +164,7 @@ namespace Improbable.OnlineServices.Common.Test
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
             IAnalyticsSender sender = new AnalyticsSenderBuilder(DevEnv, KeyVal, SourceVal)
                 .WithMaxQueueSize(3)
-                .WithMaxQueueTimeMs(5)
+                .WithMaxQueueTime(TimeSpan.FromMilliseconds(5))
                 .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                 .With(client)
                 .Build();
@@ -184,7 +184,7 @@ namespace Improbable.OnlineServices.Common.Test
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
             IAnalyticsSender sender = new AnalyticsSenderBuilder(DevEnv, KeyVal, SourceVal)
                 .WithMaxQueueSize(3)
-                .WithMaxQueueTimeMs(5000)
+                .WithMaxQueueTime(TimeSpan.FromSeconds(5))
                 .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                 .With(client)
                 .Build();

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -132,7 +132,7 @@ namespace Improbable.OnlineServices.Common.Test
                 .Send(ClassVal, TypeVal, new Dictionary<string, string>
                 {
                     { "dogs", "excellent" }
-                });
+                }, true);
 
             _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(1),
                 ItExpr.Is<HttpRequestMessage>(req => ExpectedMessage(req)),

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -56,7 +56,7 @@ namespace Improbable.OnlineServices.Common.Test
         {
             Assert.IsInstanceOf<AnalyticsSender>(
                 new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
-                    .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
+                    .WithCommandLineArgs( $"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/" )
                     .Build()
             );
         }
@@ -67,7 +67,7 @@ namespace Improbable.OnlineServices.Common.Test
             ArgumentException ex = Assert.Throws<ArgumentException>(
                 () =>
                     new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
-                        .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/")
+                        .WithCommandLineArgs( $"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/" )
                         .Build()
             );
 
@@ -128,7 +128,7 @@ namespace Improbable.OnlineServices.Common.Test
         {
             HttpClient client = new HttpClient(_messageHandlerMock.Object);
             new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
-                .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
+                .WithCommandLineArgs( $"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/" )
                 .With(client)
                 .Build()
                 .Send(ClassVal, TypeVal, new Dictionary<string, string>

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -40,7 +40,7 @@ namespace Improbable.OnlineServices.Common.Test
                     Content = new StringContent("")
                 }).Verifiable();
         }
-        
+
         private AnalyticsConfig _emptyConfig = new AnalyticsConfig("");
 
         [Test]
@@ -65,8 +65,10 @@ namespace Improbable.OnlineServices.Common.Test
         public void FailToBuildIfHttpIsNotUsedWithoutInsecureEnabled()
         {
             ArgumentException ex = Assert.Throws<ArgumentException>(
-                () => new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
-                    .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/").Build()
+                () =>
+                    new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                        .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/")
+                        .Build()
             );
 
             Assert.That(ex.Message, Contains.Substring("uses http, but only https is allowed"));
@@ -77,8 +79,10 @@ namespace Improbable.OnlineServices.Common.Test
         {
             Assert.IsInstanceOf<AnalyticsSender>(
                 new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
-                    .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/",
-                        $"--{AnalyticsCommandLineArgs.AllowInsecureEndpointName}")
+                    .WithCommandLineArgs(
+                        $"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/",
+                        $"--{AnalyticsCommandLineArgs.AllowInsecureEndpointName}"
+                    )
                     .Build()
             );
         }
@@ -114,7 +118,7 @@ namespace Improbable.OnlineServices.Common.Test
             Assert.AreEqual(KeyVal, queryCollection["key"]);
             Assert.AreEqual(development, queryCollection["analytics_environment"]);
             Assert.AreEqual(DefaultEventCategory, queryCollection["event_category"]);
-            Assert.True(Guid.TryParse((string) queryCollection["session_id"], out Guid _));
+            Assert.True(Guid.TryParse(queryCollection["session_id"], out Guid _));
 
             return request.Method == HttpMethod.Post;
         }
@@ -167,7 +171,6 @@ namespace Improbable.OnlineServices.Common.Test
             // d.e should route to *.* as there is no match
             Assert.False(config.IsEnabled("d", "e"));
             Assert.AreEqual(DefaultEventCategory, config.GetCategory("d", "e"));
-
             // d.a should route to *.a as there is not a better match
             Assert.True(config.IsEnabled("d", "a"));
             Assert.AreEqual("function", config.GetCategory("d", "a"));

--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -116,7 +116,7 @@ namespace Improbable.OnlineServices.Common.Test
             Assert.AreEqual(KeyVal, queryCollection["key"]);
             Assert.AreEqual(development, queryCollection["analytics_environment"]);
             Assert.AreEqual(DefaultEventCategory, queryCollection["event_category"]);
-            Assert.True(Guid.TryParse(queryCollection["session_id"], out Guid _));
+            Assert.True(Guid.TryParse((string) queryCollection["session_id"], out Guid _));
 
             return request.Method == HttpMethod.Post;
         }

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -66,7 +66,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         }
 
         /// <summary>
-        /// Sets the expected duration between each dispatch of the analytics event queue
+        /// Sets the expected duration between each dispatch of the analytics event queuea.
         /// </summary>
         public AnalyticsSenderBuilder WithMaxQueueTime(TimeSpan maxQueueTime)
         {

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -10,11 +10,6 @@ namespace Improbable.OnlineServices.Common.Analytics
     public class AnalyticsSenderBuilder
     {
         /// <summary>
-        /// Maximum size of the event queue before all events within it are dispatched
-        /// </summary>
-        private int _maxEventQueueSize = 10;
-
-        /// <summary>
         /// Maximum time an event should wait in the queue before being dispatched to the endpoint.
         /// May be longer if an event is added while previous events are being dispatched.
         /// </summary>
@@ -51,8 +46,8 @@ namespace Improbable.OnlineServices.Common.Analytics
                         string.Format(_insecureProtocolExceptionMessage, _endpoint.Scheme));
                 }
 
-                return new AnalyticsSender(_endpoint, _config, _environment, _gcpKey, _eventSource,
-                    _maxEventQueueSize, _maxQueueTime, _httpClient);
+                return new AnalyticsSender(_endpoint, _config, _environment, _gcpKey, _eventSource, _maxQueueTime,
+                    _httpClient);
             }
 
             return new NullAnalyticsSender();
@@ -67,15 +62,6 @@ namespace Improbable.OnlineServices.Common.Analytics
         public AnalyticsSenderBuilder With(AnalyticsConfig config)
         {
             _config = config;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the maximum size the analytics event queue should reach before the queue is dispatched
-        /// </summary>
-        public AnalyticsSenderBuilder WithMaxQueueSize(int maxQueueSize)
-        {
-            _maxEventQueueSize = maxQueueSize;
             return this;
         }
 

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -9,6 +9,17 @@ namespace Improbable.OnlineServices.Common.Analytics
 {
     public class AnalyticsSenderBuilder
     {
+        /// <summary>
+        /// Maximum size of the event queue before all events within it are dispatched
+        /// </summary>
+        private int _maxEventQueueSize = 10;
+
+        /// <summary>
+        /// Maximum time an event should wait in the queue before being dispatched to the endpoint.
+        /// May be longer if an event is added while previous events are being dispatched.
+        /// </summary>
+        private int _maxQueueTimeMs = 2500;
+        
         private readonly AnalyticsEnvironment _environment;
         private readonly string _gcpKey;
         private readonly string _eventSource;
@@ -40,7 +51,8 @@ namespace Improbable.OnlineServices.Common.Analytics
                         string.Format(_insecureProtocolExceptionMessage, _endpoint.Scheme));
                 }
 
-                return new AnalyticsSender(_endpoint, _config, _environment, _gcpKey, _eventSource, _httpClient);
+                return new AnalyticsSender(_endpoint, _config, _environment, _gcpKey, _eventSource,
+                    _maxEventQueueSize, _maxQueueTimeMs, _httpClient);
             }
 
             return new NullAnalyticsSender();
@@ -55,6 +67,24 @@ namespace Improbable.OnlineServices.Common.Analytics
         public AnalyticsSenderBuilder With(AnalyticsConfig config)
         {
             _config = config;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum size the analytics event queue should reach before the queue is dispatched
+        /// </summary>
+        public AnalyticsSenderBuilder WithMaxQueueSize(int maxQueueSize)
+        {
+            _maxEventQueueSize = maxQueueSize;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the expected duration between each dispatch of the analytics event queue
+        /// </summary>
+        public AnalyticsSenderBuilder WithMaxQueueTimeMs(int maxQueueTime)
+        {
+            _maxQueueTimeMs = maxQueueTime;
             return this;
         }
 

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -19,7 +19,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// May be longer if an event is added while previous events are being dispatched.
         /// </summary>
         private int _maxQueueTimeMs = 2500;
-        
+
         private readonly AnalyticsEnvironment _environment;
         private readonly string _gcpKey;
         private readonly string _eventSource;

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -65,7 +65,6 @@ namespace Improbable.OnlineServices.Common.Analytics
 
         public AnalyticsSenderBuilder WithCommandLineArgs(IEnumerable<string> args)
         {
-            Uri endpoint;
             Parser.Default.ParseArguments<AnalyticsCommandLineArgs>(args)
                 .WithParsed(async parsedArgs =>
                 {

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -18,7 +18,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// Maximum time an event should wait in the queue before being dispatched to the endpoint.
         /// May be longer if an event is added while previous events are being dispatched.
         /// </summary>
-        private TimeSpan _maxQueueTime = TimeSpan.FromMilliseconds(2500);
+        private TimeSpan _maxQueueTime = TimeSpan.FromMilliseconds(2000);
 
         private readonly AnalyticsEnvironment _environment;
         private readonly string _gcpKey;

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -10,6 +10,11 @@ namespace Improbable.OnlineServices.Common.Analytics
     public class AnalyticsSenderBuilder
     {
         /// <summary>
+        /// Maximum size of the event queue before all events within it are dispatched
+        /// </summary>
+        private int _maxQueueSize = 10;
+
+        /// <summary>
         /// Maximum time an event should wait in the queue before being dispatched to the endpoint.
         /// May be longer if an event is added while previous events are being dispatched.
         /// </summary>
@@ -47,7 +52,7 @@ namespace Improbable.OnlineServices.Common.Analytics
                 }
 
                 return new AnalyticsSender(_endpoint, _config, _environment, _gcpKey, _eventSource, _maxQueueTime,
-                    _httpClient);
+                    _maxQueueSize, _httpClient);
             }
 
             return new NullAnalyticsSender();
@@ -66,7 +71,16 @@ namespace Improbable.OnlineServices.Common.Analytics
         }
 
         /// <summary>
-        /// Sets the expected duration between each dispatch of the analytics event queuea.
+        /// Sets the maximum size the analytics event queue should reach before the queue is dispatched.
+        /// </summary>
+        public AnalyticsSenderBuilder WithMaxQueueSize(int maxQueueSize)
+        {
+            _maxQueueSize = maxQueueSize;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the expected duration between each dispatch of the analytics event queue.
         /// </summary>
         public AnalyticsSenderBuilder WithMaxQueueTime(TimeSpan maxQueueTime)
         {

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -65,6 +65,7 @@ namespace Improbable.OnlineServices.Common.Analytics
 
         public AnalyticsSenderBuilder WithCommandLineArgs(IEnumerable<string> args)
         {
+            Uri endpoint;
             Parser.Default.ParseArguments<AnalyticsCommandLineArgs>(args)
                 .WithParsed(async parsedArgs =>
                 {

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -18,7 +18,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// Maximum time an event should wait in the queue before being dispatched to the endpoint.
         /// May be longer if an event is added while previous events are being dispatched.
         /// </summary>
-        private int _maxQueueTimeMs = 2500;
+        private TimeSpan _maxQueueTime = TimeSpan.FromMilliseconds(2500);
 
         private readonly AnalyticsEnvironment _environment;
         private readonly string _gcpKey;
@@ -52,7 +52,7 @@ namespace Improbable.OnlineServices.Common.Analytics
                 }
 
                 return new AnalyticsSender(_endpoint, _config, _environment, _gcpKey, _eventSource,
-                    _maxEventQueueSize, _maxQueueTimeMs, _httpClient);
+                    _maxEventQueueSize, _maxQueueTime, _httpClient);
             }
 
             return new NullAnalyticsSender();
@@ -82,9 +82,9 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// <summary>
         /// Sets the expected duration between each dispatch of the analytics event queue
         /// </summary>
-        public AnalyticsSenderBuilder WithMaxQueueTimeMs(int maxQueueTime)
+        public AnalyticsSenderBuilder WithMaxQueueTime(TimeSpan maxQueueTime)
         {
-            _maxQueueTimeMs = maxQueueTime;
+            _maxQueueTime = maxQueueTime;
             return this;
         }
 

--- a/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
+++ b/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
@@ -1,4 +1,5 @@
 using CommandLine;
+using Improbable.OnlineServices.DataModel.Party;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {

--- a/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
+++ b/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
@@ -1,5 +1,4 @@
 using CommandLine;
-using Improbable.OnlineServices.DataModel.Party;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -126,7 +126,6 @@ namespace Improbable.OnlineServices.Common.Analytics
             }
         }
 
-        private double _isDispatchingEventQueue = 0;
         private readonly object _dispatchingLockObject = null;
 
         private async Task DispatchEventQueue()

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -5,10 +5,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using CommandLine;
 using Improbable.OnlineServices.Common.Analytics.Config;
 using Newtonsoft.Json;
-using Timer = System.Timers.Timer;
 
 namespace Improbable.OnlineServices.Common.Analytics
 {

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -135,6 +135,8 @@ namespace Improbable.OnlineServices.Common.Analytics
 
             // We only need to lock dequeue operations so we can ensure batches are sent together even if
             // both conditions occur at the same time - the time elapses and the queue fills at the same time.
+            // In the event of a second thread trying to dispatch at the same time as another is, we just fall through
+            // with the empty uriMap
             if (Monitor.TryEnter(_dispatchingLockObject))
             {
                 try

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using CommandLine;
 using Improbable.OnlineServices.Common.Analytics.Config;
 using Newtonsoft.Json;
 

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -142,7 +142,7 @@ namespace Improbable.OnlineServices.Common.Analytics
             var enumerable = uriMap.Select(
                 kvp => SendData(kvp.Key, new StringContent(string.Join("\n", kvp.Value)))
             );
-            foreach (var result in enumerable) await result;
+            Task.WaitAll(enumerable.ToArray());
         }
 
         private Task<HttpResponseMessage> SendData(Uri uri, StringContent content)

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -118,7 +118,10 @@ namespace Improbable.OnlineServices.Common.Analytics
 
             while (_queuedRequests.TryDequeue(out (Uri uri, string content) request))
             {
-                if (!uriMap.ContainsKey(request.uri)) uriMap[request.uri] = new List<string>();
+                if (!uriMap.ContainsKey(request.uri)) 
+                {
+                	uriMap[request.uri] = new List<string>();
+                }
                 uriMap[request.uri].Add(request.content);
             }
 

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -125,7 +125,10 @@ namespace Improbable.OnlineServices.Common.Analytics
             {
                 try
                 {
-                    if (_queuedRequests.Count == 0) return;
+                    if (_queuedRequests.Count == 0) 
+                    {
+                    	return;
+                    }
 
                     while (_queuedRequests.TryDequeue(out (Uri uri, string content) request))
                     {

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -110,7 +110,7 @@ namespace Improbable.OnlineServices.Common.Analytics
             else
             {
                 bool shouldDispatchQueue = false;
-                
+
                 lock (_queuedRequests)
                 {
                     _queuedRequests.Add((uri, JsonConvert.SerializeObject(postParams)));

--- a/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
+++ b/services/csharp/Common/Analytics/Config/AnalyticsConfig.cs
@@ -1,7 +1,4 @@
-using System;
 using System.IO;
-using System.Threading.Tasks;
-using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using EntriesList = System.Collections.Generic.Dictionary<string,

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -16,6 +16,6 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
         /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
         /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
-        void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
+        Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
     }
 }

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -15,7 +15,6 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
         /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
         /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
-        /// <param name="immediate">Determines whether or not the event should be sent immediately rather than batched</param>
         Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
     }
 }

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -16,6 +16,6 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
         /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
         /// <param name="immediate">Determines whether or not the event should be sent immediately rather than batched</param>
-        Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes, bool immediate = false);
+        Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
     }
 }

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -15,6 +15,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
         /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
         /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
-        Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
+        /// <param name="immediate">Determines whether or not the event should be sent immediately rather than batched</param>
+        Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes, bool immediate = false);
     }
 }

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -7,7 +8,7 @@ namespace Improbable.OnlineServices.Common.Analytics
     /// An interface for analytics senders, used to facilitate the NullAnalyticsSender as a black hole for analytics.
     /// Normal usage should be through the Build method in AnalyticsSender.
     /// </summary>
-    public interface IAnalyticsSender
+    public interface IAnalyticsSender : IDisposable
     {
         /// <summary>
         /// Dispatch an analytics event to an endpoint, if one has been specified
@@ -15,6 +16,6 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
         /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
         /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
-        Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
+        void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
     }
 }

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -12,6 +12,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
         {
             // This method deliberately left blank
+            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -9,7 +9,7 @@ namespace Improbable.OnlineServices.Common.Analytics
     /// </summary>
     public class NullAnalyticsSender : IAnalyticsSender
     {
-        public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
+        public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes, bool imm)
         {
             return Task.CompletedTask;
         }

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -9,9 +9,14 @@ namespace Improbable.OnlineServices.Common.Analytics
     /// </summary>
     public class NullAnalyticsSender : IAnalyticsSender
     {
-        public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
+        public void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
         {
-            return Task.CompletedTask;
+            // This method deliberately left blank
+        }
+
+        public void Dispose()
+        {
+            // This method deliberately left blank
         }
     }
 }

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -9,7 +9,7 @@ namespace Improbable.OnlineServices.Common.Analytics
     /// </summary>
     public class NullAnalyticsSender : IAnalyticsSender
     {
-        public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes, bool imm)
+        public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
         {
             return Task.CompletedTask;
         }

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -9,7 +9,7 @@ namespace Improbable.OnlineServices.Common.Analytics
     /// </summary>
     public class NullAnalyticsSender : IAnalyticsSender
     {
-        public void Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
+        public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
         {
             // This method deliberately left blank
         }


### PR DESCRIPTION
This PR adds batching to the AnalyticsSender so that messages are not immediately sent but instead batched up and sent periodically or when the batch size becomes too large.

One evil of this PR is a Task.Delay in one of the tests, but I believe it's justified as it's only 20ms (the Common.Test suite as a whole takes ~700-900ms), I *think* NUnit handles async well, and it saves any extra complexity of making a wrapper around the Task library that can be injected. I'm happy to change this to another solution if preferred, though.