### PR TITLE
Add exception handling strategies to analytics sender

### DIFF
--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -62,23 +62,22 @@ namespace Improbable.OnlineServices.Common.Analytics
 
         public AnalyticsSenderBuilder With(HttpClient client)
         {
-            _httpClient = client;
+            _httpClient = client ?? throw new ArgumentNullException();
             return this;
         }
 
         public AnalyticsSenderBuilder With(AnalyticsConfig config)
         {
-            _config = config;
+            _config = config ?? throw new ArgumentNullException();
             return this;
         }
 
         /// <summary>
-        /// Sets the strategy for handling HTTP exceptions during analytic dispatch. Silently ignores null strategies
-        /// in favour of the existing strategy.
+        /// Sets the strategy for handling HTTP exceptions during analytic dispatch.
         /// </summary>
         public AnalyticsSenderBuilder With(IDispatchExceptionStrategy strategy)
         {
-            _dispatchExceptionStrategy = strategy ?? _dispatchExceptionStrategy;
+            _dispatchExceptionStrategy = strategy ?? throw new ArgumentNullException();
             return this;
         }
 

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -147,7 +147,6 @@ namespace Improbable.OnlineServices.Common.Analytics
             }
             catch (HttpRequestException e)
             {
-                Console.WriteLine("Handling e");
                 _dispatchExceptionStrategy.ProcessException(e);
             }
         }

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using Improbable.OnlineServices.Common.Analytics.Config;
+using Improbable.OnlineServices.Common.Analytics.ExceptionHandlers;
 using Newtonsoft.Json;
 
 namespace Improbable.OnlineServices.Common.Analytics
@@ -45,6 +46,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         private readonly string _eventSource;
         private readonly int _maxEventQueueSize;
         private readonly HttpClient _httpClient;
+        private readonly IDispatchExceptionStrategy _dispatchExceptionStrategy;
         private readonly ConcurrentQueue<QueuedRequest> _queuedRequests =
             new ConcurrentQueue<QueuedRequest>();
         private long _eventId;
@@ -54,7 +56,8 @@ namespace Improbable.OnlineServices.Common.Analytics
 
 
         internal AnalyticsSender(Uri endpoint, AnalyticsConfig config, AnalyticsEnvironment environment, string gcpKey,
-            string eventSource, TimeSpan maxEventQueueDelta, int maxEventQueueSize, HttpClient httpClient)
+            string eventSource, TimeSpan maxEventQueueDelta, int maxEventQueueSize,
+            IDispatchExceptionStrategy dispatchExceptionStrategy, HttpClient httpClient)
         {
             _endpoint = endpoint;
             _config = config;
@@ -62,6 +65,7 @@ namespace Improbable.OnlineServices.Common.Analytics
             _gcpKey = gcpKey;
             _eventSource = eventSource;
             _maxEventQueueSize = maxEventQueueSize;
+            _dispatchExceptionStrategy = dispatchExceptionStrategy;
             _httpClient = httpClient;
 
             Task.Factory.StartNew(async () =>
@@ -135,9 +139,17 @@ namespace Improbable.OnlineServices.Common.Analytics
                 uriMap[request.Uri].Add(request.Content);
             }
 
-            var enumerable = uriMap.Select(
-                kvp => _httpClient.PostAsync(kvp.Key, new StringContent(string.Join("\n", kvp.Value))));
-            await Task.WhenAll(enumerable.ToArray<Task>());
+            try
+            {
+                var enumerable = uriMap.Select(
+                    kvp => _httpClient.PostAsync(kvp.Key, new StringContent(string.Join("\n", kvp.Value))));
+                await Task.WhenAll(enumerable.ToArray<Task>());
+            }
+            catch (HttpRequestException e)
+            {
+                Console.WriteLine("Handling e");
+                _dispatchExceptionStrategy.ProcessException(e);
+            }
         }
 
         private static string DictionaryToQueryString(Dictionary<string, string> urlParams)

--- a/services/csharp/Common/Analytics/DispatchExceptionLogger.cs
+++ b/services/csharp/Common/Analytics/DispatchExceptionLogger.cs
@@ -1,0 +1,7 @@
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    public class DispatchExceptionLogger
+    {
+
+    }
+}

--- a/services/csharp/Common/Analytics/DispatchExceptionLogger.cs
+++ b/services/csharp/Common/Analytics/DispatchExceptionLogger.cs
@@ -1,7 +1,0 @@
-namespace Improbable.OnlineServices.Common.Analytics
-{
-    public class DispatchExceptionLogger
-    {
-
-    }
-}

--- a/services/csharp/Common/Analytics/ExceptionHandlers/IDispatchExceptionStrategy.cs
+++ b/services/csharp/Common/Analytics/ExceptionHandlers/IDispatchExceptionStrategy.cs
@@ -1,0 +1,9 @@
+using System.Net.Http;
+
+namespace Improbable.OnlineServices.Common.Analytics.ExceptionHandlers
+{
+    public interface IDispatchExceptionStrategy
+    {
+        void ProcessException(HttpRequestException e);
+    }
+}

--- a/services/csharp/Common/Analytics/ExceptionHandlers/LogExceptionStrategy.cs
+++ b/services/csharp/Common/Analytics/ExceptionHandlers/LogExceptionStrategy.cs
@@ -1,0 +1,20 @@
+using System.Net.Http;
+using Serilog;
+
+namespace Improbable.OnlineServices.Common.Analytics.ExceptionHandlers
+{
+    public class LogExceptionStrategy : IDispatchExceptionStrategy
+    {
+        private readonly ILogger _logger;
+
+        public LogExceptionStrategy(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void ProcessException(HttpRequestException e)
+        {
+            _logger.Error(e, "Failed to dispatch analytics events to endpoint");
+        }
+    }
+}

--- a/services/csharp/Common/Analytics/ExceptionHandlers/RethrowExceptionStrategy.cs
+++ b/services/csharp/Common/Analytics/ExceptionHandlers/RethrowExceptionStrategy.cs
@@ -1,0 +1,13 @@
+using System.Net.Http;
+
+namespace Improbable.OnlineServices.Common.Analytics.ExceptionHandlers
+{
+    public class RethrowExceptionStrategy : IDispatchExceptionStrategy
+    {
+        public void ProcessException(HttpRequestException e)
+        {
+            // Rethrow the exception
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
This PR tackles the issue that, ideally, sending analytics should be low-effort. Users shouldn't have to wrap every analytics.Send(...) call with a near-identical try-catch blocks to avoid their application crashing, since it disincentives analytics sending.

Added:

* System of `DispatchExceptionStrateg[ies]` which are pretty much a layer over a simple handler (we could also use an action and allow an arbitrary lambda - open to feedback here, though it seems sensible to me to at least provide some pre-defined options)
* A log handler, which I intend to use to instrument the existing services.
* A simple handler for just re-throwing the exception so the user deals with it - essentially a wrapper around the old behaviour. This is enabled by default.
* Corresponding unit tests to verify that exceptions are routed through the system correctly and that both handlers function as expected.