### PR TITLE
Various changes to analytics in advance of instrumenting Party/

### DIFF
--- a/services/csharp/Common.Test/AnalyticsShould.cs
+++ b/services/csharp/Common.Test/AnalyticsShould.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Improbable.OnlineServices.Common.Analytics;
@@ -48,7 +47,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void BuildNullByDefault()
         {
             Assert.IsInstanceOf<NullAnalyticsSender>(
-                new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal).Build()
+                new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal).Build()
             );
         }
 
@@ -56,7 +55,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void BuildRealAnalyticsSenderIfProvidedWithEndpoint()
         {
             using (var analyticsSender =
-                new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal)
                     .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                     .Build())
             {
@@ -69,7 +68,7 @@ namespace Improbable.OnlineServices.Common.Test
         {
             var ex = Assert.Throws<ArgumentException>(
                 () =>
-                    new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                    new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal)
                         .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/")
                         .Build()
             );
@@ -81,7 +80,7 @@ namespace Improbable.OnlineServices.Common.Test
         public void AllowsHttpIfInsecureEndpointsEnabled()
         {
             using (var sender =
-                new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal)
                     .WithCommandLineArgs(
                         $"--{AnalyticsCommandLineArgs.EndpointName}", "http://example.com/",
                         $"--{AnalyticsCommandLineArgs.AllowInsecureEndpointName}"
@@ -94,7 +93,7 @@ namespace Improbable.OnlineServices.Common.Test
 
         private bool SendAnalyticEventsToHttpsEndpointExpectedMessage(HttpRequestMessage request)
         {
-            var development = AnalyticsEnvironment.Development.ToString().ToLower();
+            var environment = AnalyticsEnvironment.Testing.ToString().ToLower();
 
             Assert.IsInstanceOf<StringContent>(request.Content);
             if (request.Content is StringContent messageContent)
@@ -102,7 +101,7 @@ namespace Improbable.OnlineServices.Common.Test
                 dynamic content = JsonConvert.DeserializeObject(messageContent.ReadAsStringAsync().Result);
 
                 // TODO: Test versioning when it is added
-                Assert.AreEqual(development, content.eventEnvironment.Value);
+                Assert.AreEqual(environment, content.eventEnvironment.Value);
                 Assert.AreEqual("0", content.eventIndex.Value);
                 Assert.AreEqual(SourceVal, content.eventSource.Value);
                 Assert.AreEqual(ClassVal, content.eventClass.Value);
@@ -121,7 +120,7 @@ namespace Improbable.OnlineServices.Common.Test
 
             var queryCollection = request.RequestUri.ParseQueryString();
             Assert.AreEqual(KeyVal, queryCollection["key"]);
-            Assert.AreEqual(development, queryCollection["analytics_environment"]);
+            Assert.AreEqual(environment, queryCollection["analytics_environment"]);
             Assert.AreEqual(DefaultEventCategory, queryCollection["event_category"]);
             Assert.True(Guid.TryParse(queryCollection["session_id"], out var _));
 
@@ -133,13 +132,13 @@ namespace Improbable.OnlineServices.Common.Test
         {
             var client = new HttpClient(_messageHandlerMock.Object);
             using (var sender =
-                new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal)
                     .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                     .WithMaxQueueTime(TimeSpan.FromMilliseconds(5))
                     .With(client)
                     .Build())
             {
-                await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>
+                await sender.SendAsync(ClassVal, TypeVal, new Dictionary<string, string>
                 {
                     { "dogs", "excellent" }
                 });
@@ -157,7 +156,7 @@ namespace Improbable.OnlineServices.Common.Test
         {
             var client = new HttpClient(_messageHandlerMock.Object);
             using (var sender =
-                new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal)
                     .WithMaxQueueSize(3)
                     // This test will hopefully not take a year to run
                     .WithMaxQueueTime(TimeSpan.FromDays(365.25))
@@ -165,9 +164,9 @@ namespace Improbable.OnlineServices.Common.Test
                     .With(client)
                     .Build())
             {
-                await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>());
-                await sender.Send("class-val-2", "type-val-2", new Dictionary<string, string>());
-                await sender.Send("class-val-3", "type-val-3", new Dictionary<string, string>());
+                await sender.SendAsync(ClassVal, TypeVal, new Dictionary<string, string>());
+                await sender.SendAsync("class-val-2", "type-val-2", new Dictionary<string, string>());
+                await sender.SendAsync("class-val-3", "type-val-3", new Dictionary<string, string>());
 
                 _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(1),
                     ItExpr.IsAny<HttpRequestMessage>(),
@@ -180,14 +179,14 @@ namespace Improbable.OnlineServices.Common.Test
         {
             var client = new HttpClient(_messageHandlerMock.Object);
             using (var sender =
-                new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal)
                     .WithMaxQueueTime(TimeSpan.FromMilliseconds(5))
                     .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                     .With(client)
                     .Build())
             {
-                await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>());
-                await sender.Send("class-val-2", "type-val-2", new Dictionary<string, string>());
+                await sender.SendAsync(ClassVal, TypeVal, new Dictionary<string, string>());
+                await sender.SendAsync("class-val-2", "type-val-2", new Dictionary<string, string>());
                 await Task.Delay(20);
 
                 _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(1),
@@ -201,14 +200,14 @@ namespace Improbable.OnlineServices.Common.Test
         {
             var client = new HttpClient(_messageHandlerMock.Object);
             using (var sender =
-                new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal)
                     .WithMaxQueueTime(TimeSpan.FromSeconds(5))
                     .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                     .With(client)
                     .Build())
             {
-                await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>());
-                await sender.Send("class-val-2", "type-val-2", new Dictionary<string, string>());
+                await sender.SendAsync(ClassVal, TypeVal, new Dictionary<string, string>());
+                await sender.SendAsync("class-val-2", "type-val-2", new Dictionary<string, string>());
 
                 _messageHandlerMock.Protected().Verify("SendAsync", Times.Exactly(0),
                     ItExpr.IsAny<HttpRequestMessage>(),
@@ -298,14 +297,14 @@ namespace Improbable.OnlineServices.Common.Test
                 .Verifiable();
 
             using (var sender =
-                new AnalyticsSenderBuilder(AnalyticsEnvironment.Development, KeyVal, SourceVal)
+                new AnalyticsSenderBuilder(AnalyticsEnvironment.Testing, KeyVal, SourceVal)
                     .WithMaxQueueSize(1)
                     .WithCommandLineArgs($"--{AnalyticsCommandLineArgs.EndpointName}", "https://example.com/")
                     .With(strategyMock.Object)
                     .With(new HttpClient(httpReqHandlerMock.Object))
                     .Build())
             {
-                await sender.Send(ClassVal, TypeVal, new Dictionary<string, string>());
+                await sender.SendAsync(ClassVal, TypeVal, new Dictionary<string, string>());
 
                 strategyMock.Verify(s => s.ProcessException(exception), Times.Once());
             }

--- a/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
+++ b/services/csharp/Common/Analytics/AnalyicsSenderBuilder.cs
@@ -129,7 +129,7 @@ namespace Improbable.OnlineServices.Common.Analytics
 
                     if (!string.IsNullOrEmpty(parsedArgs.GcpKeyPath))
                     {
-                        _gcpKey = File.ReadAllText(parsedArgs.GcpKeyPath);
+                        _gcpKey = File.ReadAllText(parsedArgs.GcpKeyPath).Trim();
                     }
 
                     _environment = parsedArgs.Environment.GetValueOrDefault(_environment);

--- a/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
+++ b/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
@@ -27,6 +27,6 @@ namespace Improbable.OnlineServices.Common.Analytics
         [Option(EnvironmentName,
             HelpText = "Must be one of: testing, staging, production, live. Allows endpoint to route " +
                        "analytics from different environments to different storage buckets.")]
-        public AnalyticsEnvironment? Environment { get; set; }
+        public string Environment { get; set; }
     }
 }

--- a/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
+++ b/services/csharp/Common/Analytics/AnalyticsCommandLineArgs.cs
@@ -7,17 +7,26 @@ namespace Improbable.OnlineServices.Common.Analytics
         public const string EndpointName = "analytics.endpoint";
         public const string AllowInsecureEndpointName = "analytics.allow-insecure-endpoint";
         public const string ConfigPathName = "analytics.config-file-path";
+        public const string GcpKeyPathName = "analytics.gcp-key-path";
+        public const string EnvironmentName = "analytics.environment";
 
-        [Option(EndpointName, HelpText =
-            "Endpoint for analytics to be sent to. If not provided, then analytics are disabled")]
+        [Option(EndpointName, HelpText = "Endpoint for analytics to be sent to. If not provided, then analytics " +
+                                         "are disabled")]
         public string Endpoint { get; set; }
 
         [Option(AllowInsecureEndpointName, Default = false, HelpText = "If set, allows http URLs for the endpoint")]
         public bool AllowInsecureEndpoints { get; set; }
 
-        [Option(ConfigPathName, HelpText =
-            "Set the path for the analytics configuration file. If not set, default values " +
-            "are assumed for all analytics events.")]
+        [Option(ConfigPathName, HelpText = "Set the path for the analytics configuration file. If not set, default " +
+                                           "values are assumed for all analytics events.")]
         public string ConfigPath { get; set; }
+
+        [Option(GcpKeyPathName, HelpText = "The path from which to load the GCP key for analytics reporting.")]
+        public string GcpKeyPath { get; set; }
+
+        [Option(EnvironmentName,
+            HelpText = "Must be one of: testing, staging, production, live. Allows endpoint to route " +
+                       "analytics from different environments to different storage buckets.")]
+        public AnalyticsEnvironment? Environment { get; set; }
     }
 }

--- a/services/csharp/Common/Analytics/AnalyticsEnvironment.cs
+++ b/services/csharp/Common/Analytics/AnalyticsEnvironment.cs
@@ -1,0 +1,10 @@
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    public enum AnalyticsEnvironment
+    {
+        Testing,
+        Staging,
+        Production,
+        Live,
+    }
+}

--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -38,8 +38,10 @@ namespace Improbable.OnlineServices.Common.Analytics
         private readonly int _maxEventQueueSize;
         private readonly HttpClient _httpClient;
         private readonly IDispatchExceptionStrategy _dispatchExceptionStrategy;
+
         private readonly ConcurrentQueue<QueuedRequest> _queuedRequests =
             new ConcurrentQueue<QueuedRequest>();
+
         private long _eventId;
 
         private string CanonicalEnvironment => _environment.ToString().ToLower();
@@ -140,13 +142,14 @@ namespace Improbable.OnlineServices.Common.Analytics
                 {
                     uriMap[request.Uri] = new List<string>();
                 }
+
                 uriMap[request.Uri].Add(request.Content);
             }
 
             try
             {
-                var enumerable = uriMap.Select(
-                    kvp => _httpClient.PostAsync(kvp.Key, new StringContent(string.Join("\n", kvp.Value))));
+                var enumerable = uriMap.Select(kvp =>
+                    _httpClient.PostAsync(kvp.Key, new StringContent(string.Join("\n", kvp.Value))));
                 await Task.WhenAll(enumerable.ToArray<Task>());
             }
             catch (HttpRequestException e)

--- a/services/csharp/Common/Analytics/AnalyticsSenderClassWrapper.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSenderClassWrapper.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    public class AnalyticsSenderClassWrapper : IAnalyticsSender
+    {
+        private readonly IAnalyticsSender _wrapped;
+        private readonly string _class;
+
+        public AnalyticsSenderClassWrapper(IAnalyticsSender wrapped, string @class)
+        {
+            _wrapped = wrapped;
+            _class = @class;
+        }
+
+        public void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
+        {
+            _wrapped.Send<T>(eventClass, eventType, eventAttributes);
+        }
+
+        public Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
+        {
+            return _wrapped.SendAsync<T>(eventClass, eventType, eventAttributes);
+        }
+
+        public void Send<T>(string eventType, Dictionary<string, T> eventAttributes)
+        {
+            Send(_class, eventType, eventAttributes);
+        }
+
+        public Task SendAsync<T>(string eventType, Dictionary<string, T> eventAttributes)
+        {
+            return SendAsync<T>(_class, eventType, eventAttributes);
+        }
+
+        public void Dispose()
+        {
+            _wrapped.Dispose();
+        }
+    }
+}

--- a/services/csharp/Common/Analytics/AnalyticsSenderClassWrapper.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSenderClassWrapper.cs
@@ -35,7 +35,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         }
 
         /// <summary>
-        /// The owner is the analytics sender is still responsible for disposing it.
+        /// The owner of the analytics sender is still responsible for disposing it.
         /// </summary>
         public void Dispose()
         {

--- a/services/csharp/Common/Analytics/AnalyticsSenderClassWrapper.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSenderClassWrapper.cs
@@ -6,37 +6,39 @@ namespace Improbable.OnlineServices.Common.Analytics
     public class AnalyticsSenderClassWrapper : IAnalyticsSender
     {
         private readonly IAnalyticsSender _wrapped;
-        private readonly string _class;
+        private readonly string _eventClass;
 
-        public AnalyticsSenderClassWrapper(IAnalyticsSender wrapped, string @class)
+        public AnalyticsSenderClassWrapper(IAnalyticsSender wrapped, string eventClass)
         {
             _wrapped = wrapped;
-            _class = @class;
+            _eventClass = eventClass;
         }
 
         public void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
         {
-            _wrapped.Send<T>(eventClass, eventType, eventAttributes);
+            _wrapped.Send(eventClass, eventType, eventAttributes);
         }
 
         public Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
         {
-            return _wrapped.SendAsync<T>(eventClass, eventType, eventAttributes);
+            return _wrapped.SendAsync(eventClass, eventType, eventAttributes);
         }
 
         public void Send<T>(string eventType, Dictionary<string, T> eventAttributes)
         {
-            Send(_class, eventType, eventAttributes);
+            Send(_eventClass, eventType, eventAttributes);
         }
 
         public Task SendAsync<T>(string eventType, Dictionary<string, T> eventAttributes)
         {
-            return SendAsync<T>(_class, eventType, eventAttributes);
+            return SendAsync(_eventClass, eventType, eventAttributes);
         }
 
+        /// <summary>
+        /// The owner is the analytics sender is still responsible for disposing it.
+        /// </summary>
         public void Dispose()
         {
-            _wrapped.Dispose();
         }
     }
 }

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Improbable.OnlineServices.Common.Analytics

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Improbable.OnlineServices.Common.Analytics
@@ -16,6 +17,8 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
         /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
         /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
-        Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes);
+        void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes);
+
+        Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes);
     }
 }

--- a/services/csharp/Common/Analytics/IAnalyticsSenderExtensions.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSenderExtensions.cs
@@ -1,0 +1,13 @@
+namespace Improbable.OnlineServices.Common.Analytics
+{
+    public static class AnalyticsSenderExtensions
+    {
+        /// <summary>
+        /// A utility method for wrapping an analytics sender to provide a default event class
+        /// </summary>
+        public static AnalyticsSenderClassWrapper WithEventClass(this IAnalyticsSender sender, string eventClass)
+        {
+            return new AnalyticsSenderClassWrapper(sender, eventClass);
+        }
+    }
+}

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -9,15 +9,20 @@ namespace Improbable.OnlineServices.Common.Analytics
     /// </summary>
     public class NullAnalyticsSender : IAnalyticsSender
     {
-        public Task Send(string eventClass, string eventType, Dictionary<string, string> eventAttributes)
+        public void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
         {
-            // This method deliberately left blank
+            // This method intentionally left blank
+        }
+
+        public Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
+        {
+            // This method intentionally left blank
             return Task.CompletedTask;
         }
 
         public void Dispose()
         {
-            // This method deliberately left blank
+            // This method intentionally left blank
         }
     }
 }


### PR DESCRIPTION
This PR makes a variety of changes which made instrumenting Party (next PR) more straightforward. My focus was on minimising duplication where possible to make the user-level instrumentation as minimal as possible.

Main changes:
* Accept generic type T to Send to allow non-string data e.g. lists to be encoded into JSON correctly. For most events, T = string.
* Delete `development` environment
* Add GcpKeyPath and environment command line flags
* Split `Send` into `Send` and `SendAsync`.
* Add a `AnalyticsSenderClassWrapper` which wraps around `IAnalyticsSender` and provides some utility methods to avoid having to pass in `eventClass` every time, since it's typically the same.
   * This could easily be part of the ordinary interface with a specific default provided, but tricky behaviour if users forget to provide a default, and I don't want to require one if possible
   * This also allows the same analytics sender to have different defaults in different places - if you have e.g. two 'servers' sharing a single process, they can share a single analytics sender wrapped by different class wrappers.