### PR TITLE
Deployment pool extend grace period

### DIFF
--- a/services/k8s/deployment-pool/deployment.yaml
+++ b/services/k8s/deployment-pool/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           sources:
           - configMap:
               name: "snapshot"
-          - configMap: 
+          - configMap:
               name: "launch-config"
       containers:
       - name: deployment-pool
@@ -58,3 +58,4 @@ spec:
         - "pool-assembly"
         - --project
         - "$(SPATIAL_PROJECT)"
+      terminationGracePeriodSeconds: 300

--- a/services/k8s/deployment-pool/deployment.yaml
+++ b/services/k8s/deployment-pool/deployment.yaml
@@ -20,7 +20,7 @@ spec:
           sources:
           - configMap:
               name: "snapshot"
-          - configMap:
+          - configMap: 
               name: "launch-config"
       containers:
       - name: deployment-pool


### PR DESCRIPTION
**Description**

Currently when the deployment pool performs its cleanup as it's being stopped (see code [here](https://github.com/spatialos/online-services/blob/235aacf3b39a2eb95fc54569ec18fa05b4a9c3ce/services/csharp/DeploymentPool/DeploymentPool.cs#L52)) it might take more than 30  seconds to stop all the deployments. As a result not all of the deployments have been stopped (~ 80 deployments are usually stopped within the period). This increases the termination grace period to 300 seconds.