### PR TITLE
Instrument party and invite services

### DIFF
--- a/services/csharp/Party.Test/CreateInviteShould.cs
+++ b/services/csharp/Party.Test/CreateInviteShould.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Invite;
@@ -38,7 +39,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object);
+            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/CreatePartyShould.cs
+++ b/services/csharp/Party.Test/CreatePartyShould.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Party;
@@ -37,7 +38,7 @@ namespace Party.Test
             _mockMemoryStoreClient.Setup(client => client.Dispose()).Verifiable();
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object);
+            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]
@@ -61,7 +62,8 @@ namespace Party.Test
             // Setup the client such that it will claim that TestLeader isn't a member of any party and such it will 
             // return a party id for some particular parameters.
             IEnumerable<Entry> created = null;
-            _mockMemoryStoreClient.Setup(client => client.GetAsync<Member>(TestLeaderPlayerId)).ReturnsAsync((Member) null);
+            _mockMemoryStoreClient.Setup(client => client.GetAsync<Member>(TestLeaderPlayerId))
+                .ReturnsAsync((Member) null);
             _mockTransaction.Setup(tr => tr.CreateAll(It.IsAny<IEnumerable<Entry>>()))
                 .Callback<IEnumerable<Entry>>(entries => created = entries);
 

--- a/services/csharp/Party.Test/DeleteInviteShould.cs
+++ b/services/csharp/Party.Test/DeleteInviteShould.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Invite;
@@ -33,7 +34,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object);
+            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]
@@ -85,7 +86,8 @@ namespace Party.Test
             // Check that an EntryNotFoundException is thrown as a result.
             var context = Util.CreateFakeCallContext(SenderPlayerId, "");
             var request = new DeleteInviteRequest { InviteId = _invite.Id };
-            var exception = Assert.ThrowsAsync<EntryNotFoundException>(() => _inviteService.DeleteInvite(request, context));
+            var exception =
+                Assert.ThrowsAsync<EntryNotFoundException>(() => _inviteService.DeleteInvite(request, context));
             Assert.AreEqual("No invites found for the sender", exception.Message);
         }
 
@@ -102,7 +104,8 @@ namespace Party.Test
             // Check that an EntryNotFoundException is thrown as a result.
             var context = Util.CreateFakeCallContext(SenderPlayerId, "");
             var request = new DeleteInviteRequest { InviteId = _invite.Id };
-            var exception = Assert.ThrowsAsync<EntryNotFoundException>(() => _inviteService.DeleteInvite(request, context));
+            var exception =
+                Assert.ThrowsAsync<EntryNotFoundException>(() => _inviteService.DeleteInvite(request, context));
             Assert.AreEqual("No invites found for the receiver", exception.Message);
         }
 

--- a/services/csharp/Party.Test/DeletePartyShould.cs
+++ b/services/csharp/Party.Test/DeletePartyShould.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Party;
@@ -36,7 +37,7 @@ namespace Party.Test
             _mockMemoryStoreClient.Setup(client => client.CreateTransaction()).Returns(_mockTransaction.Object);
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object);
+            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/GetInviteShould.cs
+++ b/services/csharp/Party.Test/GetInviteShould.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.Proto.Invite;
 using MemoryStore;
 using Moq;
@@ -17,7 +18,7 @@ namespace Party.Test
         private const string PartyId = "EU";
 
         private static readonly IDictionary<string, string> _metadata = new Dictionary<string, string>
-            {{"deadline", "29032019?"}};
+            { { "deadline", "29032019?" } };
 
         private InviteDataModel _storedInvite;
         private Mock<ITransaction> _mockTransaction;
@@ -35,7 +36,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object);
+            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/GetPartyByPlayerIdShould.cs
+++ b/services/csharp/Party.Test/GetPartyByPlayerIdShould.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Party;
 using MemoryStore;
@@ -16,7 +17,7 @@ namespace Party.Test
         private const string Pit = "PIT";
 
         private static readonly Dictionary<string, string> _testMetadata = new Dictionary<string, string>
-            {{"location", "Paris"}};
+            { { "location", "Paris" } };
 
         private static readonly PartyDataModel _party =
             new PartyDataModel(TestPlayerId, Pit, 2, 5, _testMetadata);
@@ -31,7 +32,7 @@ namespace Party.Test
             _mockMemoryStoreClient.Setup(client => client.Dispose()).Verifiable();
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object);
+            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/JoinPartyShould.cs
+++ b/services/csharp/Party.Test/JoinPartyShould.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Party;
@@ -40,7 +41,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object);
+            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/KickOutPlayerShould.cs
+++ b/services/csharp/Party.Test/KickOutPlayerShould.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Party;
@@ -41,7 +42,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object);
+            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/LeavePartyShould.cs
+++ b/services/csharp/Party.Test/LeavePartyShould.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Party;
@@ -37,7 +38,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object);
+            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/ListAllInvitesShould.cs
+++ b/services/csharp/Party.Test/ListAllInvitesShould.cs
@@ -1,4 +1,5 @@
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Invite;
 using MemoryStore;
@@ -41,7 +42,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object);
+            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/UpdateInviteShould.cs
+++ b/services/csharp/Party.Test/UpdateInviteShould.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.Proto.Invite;
 using MemoryStore;
@@ -44,7 +45,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object);
+            _inviteService = new InviteServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party.Test/UpdatePartyShould.cs
+++ b/services/csharp/Party.Test/UpdatePartyShould.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Grpc.Core;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.Proto.Party;
 using MemoryStore;
@@ -63,7 +64,7 @@ namespace Party.Test
 
             var memoryStoreClientManager = new Mock<IMemoryStoreClientManager<IMemoryStoreClient>>(MockBehavior.Strict);
             memoryStoreClientManager.Setup(manager => manager.GetClient()).Returns(_mockMemoryStoreClient.Object);
-            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object);
+            _partyService = new PartyServiceImpl(memoryStoreClientManager.Object, new NullAnalyticsSender());
         }
 
         [Test]

--- a/services/csharp/Party/InviteServiceImpl.cs
+++ b/services/csharp/Party/InviteServiceImpl.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Improbable.OnlineServices.Common;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
 using Improbable.OnlineServices.Proto.Invite;
@@ -18,13 +19,17 @@ namespace Party
     public class InviteServiceImpl : InviteService.InviteServiceBase
     {
         private readonly IMemoryStoreClientManager<IMemoryStoreClient> _memoryStoreClientManager;
+        private readonly AnalyticsSenderClassWrapper _analytics;
 
-        public InviteServiceImpl(IMemoryStoreClientManager<IMemoryStoreClient> memoryStoreClientManager)
+        public InviteServiceImpl(IMemoryStoreClientManager<IMemoryStoreClient> memoryStoreClientManager,
+            IAnalyticsSender analytics)
         {
             _memoryStoreClientManager = memoryStoreClientManager;
+            _analytics = analytics.WithEventClass("gateway_invite");
         }
 
-        public override async Task<CreateInviteResponse> CreateInvite(CreateInviteRequest request, ServerCallContext context)
+        public override async Task<CreateInviteResponse> CreateInvite(CreateInviteRequest request,
+            ServerCallContext context)
         {
             var playerId = AuthHeaders.ExtractPlayerId(context);
 
@@ -89,11 +94,20 @@ namespace Party
                     transaction.UpdateAll(entitiesToUpdate);
                 }
 
+                _analytics.Send("player_invited_to_party", new Dictionary<string, string>
+                {
+                    { "playerId", invite.ReceiverId },
+                    { "partyId", party.Id },
+                    { "playerIdInviter", playerId },
+                    { "inviteId", invite.Id }
+                });
+
                 return new CreateInviteResponse { InviteId = invite.Id };
             }
         }
 
-        public override async Task<DeleteInviteResponse> DeleteInvite(DeleteInviteRequest request, ServerCallContext context)
+        public override async Task<DeleteInviteResponse> DeleteInvite(DeleteInviteRequest request,
+            ServerCallContext context)
         {
             var playerId = AuthHeaders.ExtractPlayerId(context);
 
@@ -129,6 +143,14 @@ namespace Party
                     transaction.DeleteAll(new List<InviteDataModel> { invite });
                     transaction.UpdateAll(new List<PlayerInvites> { senderInvites, receiverInvites });
                 }
+
+                _analytics.Send("player_invite_to_party_revoked", new Dictionary<string, string>
+                {
+                    { "playerId", invite.ReceiverId },
+                    { "partyId", invite.PartyId },
+                    { "playerIdInviter", playerId },
+                    { "inviteId", invite.Id }
+                });
             }
 
             return new DeleteInviteResponse();
@@ -136,7 +158,8 @@ namespace Party
 
         // Updates the metadata and current status. Sender, receiver and party id are ignored.
         // TODO: consider moving to FieldMasks.
-        public override async Task<UpdateInviteResponse> UpdateInvite(UpdateInviteRequest request, ServerCallContext context)
+        public override async Task<UpdateInviteResponse> UpdateInvite(UpdateInviteRequest request,
+            ServerCallContext context)
         {
             var playerId = AuthHeaders.ExtractPlayerId(context);
 

--- a/services/csharp/Party/PartyServerCommandLineArgs.cs
+++ b/services/csharp/Party/PartyServerCommandLineArgs.cs
@@ -1,10 +1,11 @@
 using System;
 using CommandLine;
 using Improbable.OnlineServices.Base.Server;
+using Improbable.OnlineServices.Common.Analytics;
 
 namespace Party
 {
-    public class PartyServerCommandLineArgs : CommandLineArgs
+    public class PartyServerCommandLineArgs : CommandLineArgs, IAnalyticsCommandLineArgs
     {
         [Option("redis_connection_string", HelpText = "The connection string for redis (host:port)",
             Default = "127.0.0.1:6379")]
@@ -30,5 +31,12 @@ namespace Party
                 throw new ArgumentException("DefaultMinMembers cannot be negative");
             }
         }
+
+        // Analytics args
+        public string Endpoint { get; set; }
+        public bool AllowInsecureEndpoints { get; set; }
+        public string ConfigPath { get; set; }
+        public string GcpKeyPath { get; set; }
+        public string Environment { get; set; }
     }
 }

--- a/services/csharp/Party/PartyServerCommandLineArgs.cs
+++ b/services/csharp/Party/PartyServerCommandLineArgs.cs
@@ -32,11 +32,12 @@ namespace Party
             }
         }
 
-        // Analytics args
+        #region IAnalyticsCommandLineArgs
         public string Endpoint { get; set; }
         public bool AllowInsecureEndpoints { get; set; }
         public string ConfigPath { get; set; }
         public string GcpKeyPath { get; set; }
         public string Environment { get; set; }
+        #endregion
     }
 }

--- a/services/csharp/Party/PartyServiceImpl.cs
+++ b/services/csharp/Party/PartyServiceImpl.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using CSharpx;
 using Grpc.Core;
 using Improbable.OnlineServices.Common;
 using Improbable.OnlineServices.Common.Analytics;
@@ -117,12 +116,15 @@ namespace Party
                     throw new TransactionAbortedException();
                 }
 
-                party.GetMembers().ForEach(m => _analytics.Send(
-                    "player_left_cancelled_party", new Dictionary<string, string>
-                    {
-                        { "playerId", playerId },
-                        { "partyId", party.Id }
-                    }));
+                foreach (var m in party.GetMembers())
+                {
+                    _analytics.Send(
+                        "player_left_cancelled_party", new Dictionary<string, string>
+                        {
+                            { "playerId", playerId },
+                            { "partyId", party.Id }
+                        });
+                }
 
                 _analytics.Send("player_cancelled_party", new Dictionary<string, string>
                 {

--- a/services/csharp/Party/PartyServiceImpl.cs
+++ b/services/csharp/Party/PartyServiceImpl.cs
@@ -2,11 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CSharpx;
 using Grpc.Core;
 using Improbable.OnlineServices.Common;
+using Improbable.OnlineServices.Common.Analytics;
 using Improbable.OnlineServices.DataModel;
 using Improbable.OnlineServices.DataModel.Party;
-using Improbable.OnlineServices.Proto.Invite;
 using Improbable.OnlineServices.Proto.Party;
 using MemoryStore;
 using Serilog;
@@ -22,10 +23,13 @@ namespace Party
     public class PartyServiceImpl : PartyService.PartyServiceBase
     {
         private readonly IMemoryStoreClientManager<IMemoryStoreClient> _memoryStoreClientManager;
+        private readonly AnalyticsSenderClassWrapper _analytics;
 
-        public PartyServiceImpl(IMemoryStoreClientManager<IMemoryStoreClient> memoryStoreClientManager)
+        public PartyServiceImpl(IMemoryStoreClientManager<IMemoryStoreClient> memoryStoreClientManager,
+            IAnalyticsSender analytics)
         {
             _memoryStoreClientManager = memoryStoreClientManager;
+            _analytics = analytics.WithEventClass("gateway_party");
         }
 
         public override Task<CreatePartyResponse> CreateParty(CreatePartyRequest request, ServerCallContext context)
@@ -52,6 +56,12 @@ namespace Party
                 transaction.CreateAll(new List<Entry> { party, leader });
             }
 
+            _analytics.Send("player_created_party", new Dictionary<string, string>
+            {
+                { "playerId", playerId },
+                { "partyId", party.Id },
+            });
+
             return Task.FromResult(new CreatePartyResponse { PartyId = party.Id });
         }
 
@@ -69,7 +79,8 @@ namespace Party
             }
         }
 
-        public override async Task<DeletePartyResponse> DeleteParty(DeletePartyRequest request, ServerCallContext context)
+        public override async Task<DeletePartyResponse> DeleteParty(DeletePartyRequest request,
+            ServerCallContext context)
         {
             var playerId = AuthHeaders.ExtractPlayerId(context);
 
@@ -105,6 +116,19 @@ namespace Party
                     // If one of the members has left the party, it is safe to retry this RPC.
                     throw new TransactionAbortedException();
                 }
+
+                party.GetMembers().ForEach(m => _analytics.Send(
+                    "player_left_cancelled_party", new Dictionary<string, string>
+                    {
+                        { "playerId", playerId },
+                        { "partyId", party.Id }
+                    }));
+
+                _analytics.Send("player_cancelled_party", new Dictionary<string, string>
+                {
+                    { "playerId", playerId },
+                    { "partyId", party.Id }
+                });
             }
 
             return new DeletePartyResponse();
@@ -137,23 +161,29 @@ namespace Party
                 var playerInvites = await memClient.GetAsync<PlayerInvites>(playerId);
                 if (playerInvites == null)
                 {
-                    throw new RpcException(new Status(StatusCode.FailedPrecondition, "The player is not invited to this party"));
+                    throw new RpcException(new Status(StatusCode.FailedPrecondition,
+                        "The player is not invited to this party"));
                 }
-                var invited = (await Task.WhenAll(playerInvites.InboundInviteIds
+
+                var invites = (await Task.WhenAll(playerInvites.InboundInviteIds
                         .Select(invite => memClient.GetAsync<Invite>(invite))))
-                        .Where(invite =>
+                    .Where(invite =>
+                    {
+                        if (invite == null)
                         {
-                            if (invite == null)
-                            {
-                                Log.Logger.Warning("Failed to fetch an invite for {player}", playerId);
-                            }
-                            return invite != null;
-                        })
-                        .Any(invite => invite.CurrentStatus == Invite.Status.Pending && invite.ReceiverId == playerId);
+                            Log.Logger.Warning("Failed to fetch an invite for {player}", playerId);
+                        }
+
+                        return invite != null;
+                    }).ToList();
+
+                var invited = invites
+                    .Any(invite => invite.CurrentStatus == Invite.Status.Pending && invite.ReceiverId == playerId);
 
                 if (!invited)
                 {
-                    throw new RpcException(new Status(StatusCode.FailedPrecondition, "The player is not invited to this party"));
+                    throw new RpcException(new Status(StatusCode.FailedPrecondition,
+                        "The player is not invited to this party"));
                 }
 
 
@@ -183,6 +213,19 @@ namespace Party
                     transaction.CreateAll(new List<Entry> { partyToJoin.GetMember(playerId) });
                     transaction.UpdateAll(new List<Entry> { partyToJoin });
                 }
+
+                _analytics.Send("player_joined_party", new Dictionary<string, object>
+                {
+                    { "playerId", playerId },
+                    { "partyId", partyToJoin.Id },
+                    {
+                        "invites", invites.Select(invite => new Dictionary<string, string>
+                        {
+                            { "inviteId", invite.Id },
+                            { "playerIdInviter", invite.SenderId }
+                        })
+                    }
+                });
 
                 return new JoinPartyResponse { Party = ConvertToProto(partyToJoin) };
             }
@@ -219,7 +262,8 @@ namespace Party
                 var evictedTask = memClient.GetAsync<Member>(request.EvictedPlayerId);
                 Task.WaitAll(initiatorTask, evictedTask);
 
-                var initiator = initiatorTask.Result ?? throw new RpcException(new Status(StatusCode.NotFound, "The initiator player is not a member of any party"));
+                var initiator = initiatorTask.Result ?? throw new RpcException(new Status(StatusCode.NotFound,
+                                    "The initiator player is not a member of any party"));
 
                 // If the evicted has already left the party, we should return early.
                 var evicted = evictedTask.Result;
@@ -256,6 +300,13 @@ namespace Party
                     transaction.DeleteAll(new List<Entry> { evicted });
                     transaction.UpdateAll(new List<Entry> { party });
                 }
+
+                _analytics.Send("player_kicked_from_party", new Dictionary<string, string>
+                {
+                    { "playerId", evicted.Id },
+                    { "partyId", party.Id },
+                    { "playerIdKicker", playerId }
+                });
             }
 
             return new KickOutPlayerResponse();
@@ -295,6 +346,12 @@ namespace Party
                     transaction.DeleteAll(new List<Entry> { memberToDelete });
                     transaction.UpdateAll(new List<Entry> { party });
                 }
+
+                _analytics.Send("player_left_party", new Dictionary<string, string>
+                {
+                    { "playerId", playerId },
+                    { "partyId", party.Id }
+                });
             }
         }
 

--- a/services/csharp/Party/PartyServiceImpl.cs
+++ b/services/csharp/Party/PartyServiceImpl.cs
@@ -399,6 +399,20 @@ namespace Party
                     transaction.UpdateAll(new List<Entry> { party });
                 }
 
+                _analytics.Send("player_updated_party", new Dictionary<string, object>
+                {
+                    { "playerId", playerId },
+                    { "partyId", party.Id },
+                    {
+                        "newPartyState", new Dictionary<string, object>
+                        {
+                            { "partyLeaderId", updatedParty.LeaderPlayerId },
+                            { "maxMembers", updatedParty.MaxMembers },
+                            { "minMembers", updatedParty.MinMembers }
+                        }
+                    }
+                });
+
                 return new UpdatePartyResponse { Party = ConvertToProto(party) };
             }
         }

--- a/services/csharp/Party/Program.cs
+++ b/services/csharp/Party/Program.cs
@@ -35,7 +35,7 @@ namespace Party
             ThreadPool.GetMaxThreads(out var workerThreads, out var ioThreads);
             ThreadPool.SetMinThreads(workerThreads, ioThreads);
 
-            new Parser(w => w.IgnoreUnknownArguments = true).ParseArguments<PartyServerCommandLineArgs>(args)
+            Parser.Default.ParseArguments<PartyServerCommandLineArgs>(args)
                 .WithParsed(parsedArgs =>
                 {
                     parsedArgs.Validate();


### PR DESCRIPTION
Nothing new in this PR from what was previously in the other PR except for how the command line arg class is set up.

There is a little redundancy in PartyServiceCommandLineArgs now, but some nice benefits:

* Don't need to parse twice
* Can still forbid unknown arguments