### PR TITLE
fix analytics sender

### DIFF
--- a/services/csharp/Common/Analytics/AnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSender.cs
@@ -104,7 +104,7 @@ namespace Improbable.OnlineServices.Common.Analytics
         private Dictionary<string, string> PostParams<T>(string eventClass, string eventType,
             Dictionary<string, T> eventAttributes, long eventId, string playerId = null)
         {
-            IDictionary<string, string> eventDict = new Dictionary<string, string>
+            var eventDict = new Dictionary<string, string>
             {
                 { "eventEnvironment", CanonicalEnvironment },
                 { "eventIndex", eventId.ToString() },
@@ -118,7 +118,7 @@ namespace Improbable.OnlineServices.Common.Analytics
                 { "eventAttributes", JsonConvert.SerializeObject(eventAttributes) },
             };
             if (!String.IsNullOrEmpty(playerId)) {
-                eventDict.Add(new KeyValuePair<string, string>("playerId", playerId));
+                eventDict.Add("playerId", playerId);
             }
             return (Dictionary<string, string>) eventDict;
         }

--- a/services/csharp/Common/Analytics/AnalyticsSenderClassWrapper.cs
+++ b/services/csharp/Common/Analytics/AnalyticsSenderClassWrapper.cs
@@ -14,24 +14,24 @@ namespace Improbable.OnlineServices.Common.Analytics
             _eventClass = eventClass;
         }
 
-        public void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
+        public void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes, string playerId = null)
         {
-            _wrapped.Send(eventClass, eventType, eventAttributes);
+            _wrapped.Send(eventClass, eventType, eventAttributes, playerId);
         }
 
-        public Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
+        public Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes, string playerId = null)
         {
-            return _wrapped.SendAsync(eventClass, eventType, eventAttributes);
+            return _wrapped.SendAsync(eventClass, eventType, eventAttributes, playerId);
         }
 
-        public void Send<T>(string eventType, Dictionary<string, T> eventAttributes)
+        public void Send<T>(string eventType, Dictionary<string, T> eventAttributes, string playerId = null)
         {
-            Send(_eventClass, eventType, eventAttributes);
+            Send(_eventClass, eventType, eventAttributes, playerId);
         }
 
-        public Task SendAsync<T>(string eventType, Dictionary<string, T> eventAttributes)
+        public Task SendAsync<T>(string eventType, Dictionary<string, T> eventAttributes, string playerId = null)
         {
-            return SendAsync(_eventClass, eventType, eventAttributes);
+            return SendAsync(_eventClass, eventType, eventAttributes, playerId);
         }
 
         /// <summary>

--- a/services/csharp/Common/Analytics/IAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/IAnalyticsSender.cs
@@ -15,9 +15,10 @@ namespace Improbable.OnlineServices.Common.Analytics
         /// </summary>
         /// <param name="eventClass">A high level identifier for the event, e.g. deployment or gateway</param>
         /// <param name="eventType">A more specific identifier for the event, e.g. `join`</param>
-        /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. user ID or queue duration</param>
-        void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes);
+        /// <param name="eventAttributes">A dictionary of k/v data about the event, e.g. queue duration</param>
+        /// /// <param name="playerId">Optional, the ID of the player if available</param>
+        void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes, string playerId = null);
 
-        Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes);
+        Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes, string playerId = null);
     }
 }

--- a/services/csharp/Common/Analytics/NullAnalyticsSender.cs
+++ b/services/csharp/Common/Analytics/NullAnalyticsSender.cs
@@ -9,12 +9,12 @@ namespace Improbable.OnlineServices.Common.Analytics
     /// </summary>
     public class NullAnalyticsSender : IAnalyticsSender
     {
-        public void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
+        public void Send<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes, string playerId = null)
         {
             // This method intentionally left blank
         }
 
-        public Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes)
+        public Task SendAsync<T>(string eventClass, string eventType, Dictionary<string, T> eventAttributes, string playerId = null)
         {
             // This method intentionally left blank
             return Task.CompletedTask;


### PR DESCRIPTION
This PR introduces three things:

- It pulls `playerId` out of eventAttributes, and turns it into an optional argument to pass in while using the `.Send()` method. If it is passed, it is now a root key of the event JSON object, instead of being inside `eventAttributes`. If it is not passed, it is simply not present in the JSON object. This change was requested by NWX.
- The analytics configuration was not working properly, disabling events did not actually prevent them from being sent. This is now fixed.
- `eventTimestamp` is upgraded from ToUnixTimeSeconds to ToUnixTimeMilliseconds, which is actually very helpful when there are loads of events being generated & you are sorting them by `eventTimestamp`.