### PR TITLE
instrumented Gateway

### DIFF
--- a/services/csharp/DataModel.Test/EntryDeserializeShould.cs
+++ b/services/csharp/DataModel.Test/EntryDeserializeShould.cs
@@ -100,7 +100,7 @@ namespace Improbable.OnlineServices.DataModel.Test
         public void ReturnAnEquivalentPlayerJoinRequest()
         {
             var playerJoinRequest =
-                new PlayerJoinRequest("Leader", "PIT", "type", new Dictionary<string, string> { { "cmf", "cmz" } });
+                new PlayerJoinRequest("Leader", "PIT", "type", "MatchRequestId", "partyId", new Dictionary<string, string> { { "cmf", "cmz" } });
             playerJoinRequest.AssignMatch("deployment-id", "deployment-name");
             var serializedPlayerJoinRequest = JsonConvert.SerializeObject(playerJoinRequest);
             var deserializedPlayerJoinRequest =

--- a/services/csharp/DataModel/DataModel.csproj
+++ b/services/csharp/DataModel/DataModel.csproj
@@ -7,6 +7,7 @@
     <Version>1.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 </Project>

--- a/services/csharp/DataModel/Entry.cs
+++ b/services/csharp/DataModel/Entry.cs
@@ -6,6 +6,7 @@ namespace Improbable.OnlineServices.DataModel
     public abstract class Entry
     {
         public string Id { get; protected set; }
+        
         [JsonIgnore] public string PreviousState { get; set; }
 
         public string SerializeToJson()

--- a/services/csharp/DataModel/Gateway/PartyJoinRequest.cs
+++ b/services/csharp/DataModel/Gateway/PartyJoinRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 using Newtonsoft.Json;
 using PartyDataModel = Improbable.OnlineServices.DataModel.Party.Party;
 
@@ -7,8 +8,12 @@ namespace Improbable.OnlineServices.DataModel.Gateway
 {
     public class PartyJoinRequest : QueuedEntry
     {
+        public string MatchRequestId { get; }
+        public string PartyId { get; private set; }
+
         public PartyJoinRequest(PartyDataModel party, string type, Dictionary<string, string> metadata)
         {
+            MatchRequestId = Guid.NewGuid().ToString();
             Id = party.Id;
             Party = new PartyDataModel(party);
             Type = type;
@@ -18,8 +23,9 @@ namespace Improbable.OnlineServices.DataModel.Gateway
 
         [JsonConstructor]
         public PartyJoinRequest(string id, PartyDataModel party, string type, Dictionary<string, string> metadata,
-            string queueName, double score)
+            string queueName, double score, string matchRequestId = null)
         {
+            MatchRequestId = matchRequestId ?? Guid.NewGuid().ToString();
             Id = party.Id;
             Party = party;
             Type = type;

--- a/services/csharp/DataModel/Gateway/PlayerJoinRequest.cs
+++ b/services/csharp/DataModel/Gateway/PlayerJoinRequest.cs
@@ -1,13 +1,20 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
 using Newtonsoft.Json;
 
 namespace Improbable.OnlineServices.DataModel.Gateway
 {
     public class PlayerJoinRequest : Entry
     {
+        public string MatchRequestId { get; }
+        public string PartyId { get; private set; }
+
         public PlayerJoinRequest(string playerIdentity, string playerIdentityToken, string type,
-            Dictionary<string, string> metadata)
+            string matchRequestId, string partyId, Dictionary<string, string> metadata)
         {
+            MatchRequestId = matchRequestId;
+            PartyId = partyId;
             Id = playerIdentity;
             PlayerIdentity = playerIdentity;
             PlayerIdentityToken = playerIdentityToken;
@@ -17,9 +24,11 @@ namespace Improbable.OnlineServices.DataModel.Gateway
         }
 
         [JsonConstructor]
-        public PlayerJoinRequest(string id, string playerIdentity, string playerIdentityToken, string type,
-            Dictionary<string, string> metadata, MatchState state, string deploymentId, string deploymentName)
+        public PlayerJoinRequest(string id, string playerIdentity, string playerIdentityToken, string type, Dictionary<string, string> metadata,
+            MatchState state, string deploymentId, string deploymentName, string matchRequestId = null, string partyId = null)
         {
+            MatchRequestId = matchRequestId ?? Guid.NewGuid().ToString();
+            PartyId = partyId ?? Guid.NewGuid().ToString();
             Id = playerIdentity;
             PlayerIdentity = playerIdentity;
             PlayerIdentityToken = playerIdentityToken;

--- a/services/csharp/Gateway.Test/OperationsServiceDeleteOperationShould.cs
+++ b/services/csharp/Gateway.Test/OperationsServiceDeleteOperationShould.cs
@@ -61,9 +61,9 @@ namespace Gateway.Test
             _memoryStoreClient.Setup(client => client.GetAsync<PartyJoinRequest>(_party.Id))
                 .ReturnsAsync(new PartyJoinRequest(_party, "", null));
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>(LeaderId))
-                .ReturnsAsync(new PlayerJoinRequest(LeaderId, "", "", null));
+                .ReturnsAsync(new PlayerJoinRequest(LeaderId, "", "", "", "", null));
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>(PlayerId))
-                .ReturnsAsync(new PlayerJoinRequest(PlayerId, "", "", null));
+                .ReturnsAsync(new PlayerJoinRequest(PlayerId, "", "", "", "", null));
 
             var deleted = new List<Entry>();
             _transaction.Setup(tx => tx.DeleteAll(It.IsAny<IEnumerable<Entry>>()))
@@ -100,9 +100,9 @@ namespace Gateway.Test
             _memoryStoreClient.Setup(client => client.GetAsync<PartyJoinRequest>(_party.Id))
                 .ReturnsAsync(new PartyJoinRequest(_party, "", null));
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>(LeaderId))
-                .ReturnsAsync(new PlayerJoinRequest(LeaderId, "", "", null));
+                .ReturnsAsync(new PlayerJoinRequest(LeaderId, "", "", "", "", null));
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>(PlayerId))
-                .ReturnsAsync(new PlayerJoinRequest(PlayerId, "", "", null));
+                .ReturnsAsync(new PlayerJoinRequest(PlayerId, "", "", "", "", null));
 
             _transaction.Setup(tr => tr.RemoveAllFromQueue(It.IsAny<IEnumerable<QueuedEntry>>()));
             _transaction.Setup(tr => tr.Dispose()).Throws(new EntryNotFoundException(_party.Id));
@@ -123,9 +123,9 @@ namespace Gateway.Test
             _memoryStoreClient.Setup(client => client.GetAsync<PartyJoinRequest>(_party.Id))
                 .ReturnsAsync(new PartyJoinRequest(_party, "", null));
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>(LeaderId))
-                .ReturnsAsync(new PlayerJoinRequest(LeaderId, "", "", null));
+                .ReturnsAsync(new PlayerJoinRequest(LeaderId, "", "", "", "", null));
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>(PlayerId))
-                .ReturnsAsync(new PlayerJoinRequest(PlayerId, "", "", null));
+                .ReturnsAsync(new PlayerJoinRequest(PlayerId, "", "", "", "", null));
 
             _transaction.Setup(tr => tr.UpdateAll(It.IsAny<IEnumerable<Entry>>()));
             _transaction.Setup(tr => tr.RemoveAllFromQueue(It.IsAny<IEnumerable<QueuedEntry>>()));
@@ -146,9 +146,9 @@ namespace Gateway.Test
             _memoryStoreClient.Setup(client => client.GetAsync<PartyJoinRequest>(_party.Id))
                 .ReturnsAsync(new PartyJoinRequest(_party, "", null));
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>(LeaderId))
-                .ReturnsAsync(new PlayerJoinRequest(LeaderId, "", "", null));
+                .ReturnsAsync(new PlayerJoinRequest(LeaderId, "", "", "", "", null));
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>(PlayerId))
-                .ReturnsAsync(new PlayerJoinRequest(PlayerId, "", "", null));
+                .ReturnsAsync(new PlayerJoinRequest(PlayerId, "", "", "", "", null));
 
             _transaction.Setup(tr => tr.UpdateAll(It.IsAny<IEnumerable<Entry>>()));
             _transaction.Setup(tr => tr.RemoveAllFromQueue(It.IsAny<IEnumerable<QueuedEntry>>()));

--- a/services/csharp/Gateway.Test/OperationsServiceGetOperationShould.cs
+++ b/services/csharp/Gateway.Test/OperationsServiceGetOperationShould.cs
@@ -62,7 +62,7 @@ namespace Gateway.Test
         [Test]
         public void ReturnUnavailableErrorIfTransactionAborted()
         {
-            var joinReq = new PlayerJoinRequest("test_op", "", "", null);
+            var joinReq = new PlayerJoinRequest("test_op", "", "", "", "", null);
             joinReq.State = MatchState.Matched;
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>("test_op")).ReturnsAsync(joinReq);
             _transaction.Setup(tx => tx.DeleteAll(It.IsAny<IEnumerable<Entry>>()))
@@ -78,7 +78,7 @@ namespace Gateway.Test
         [Test]
         public void ReturnOperationWithResultIfMatched()
         {
-            var joinReq = new PlayerJoinRequest("testplayer", "test-player-token", "open_world", null);
+            var joinReq = new PlayerJoinRequest("testplayer", "test-player-token", "open_world", "test-request-id", "test-party", null);
             joinReq.AssignMatch("1234", "deployment1234");
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>("test_op")).ReturnsAsync(joinReq);
             _authClient.Setup(client => client.CreateLoginToken(new CreateLoginTokenRequest
@@ -110,7 +110,7 @@ namespace Gateway.Test
         [Test]
         public void ReturnOperationWithNotDoneIfStateMatching()
         {
-            var joinReq = new PlayerJoinRequest("test_op", "", "", null);
+            var joinReq = new PlayerJoinRequest("test_op", "", "", "", "", null);
             joinReq.State = MatchState.Matching;
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>("test_op")).ReturnsAsync(joinReq);
             var context = Util.CreateFakeCallContext("test_op", Pit);
@@ -125,7 +125,7 @@ namespace Gateway.Test
         [Test]
         public void ReturnOperationWithNotDoneIfStateRequested()
         {
-            var joinReq = new PlayerJoinRequest("test_op", "", "", null);
+            var joinReq = new PlayerJoinRequest("test_op", "", "", "", "", null);
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>("test_op")).ReturnsAsync(joinReq);
             var context = Util.CreateFakeCallContext("test_op", Pit);
             var resp = _service.GetOperation(new GetOperationRequest { Name = "test_op" }, context);
@@ -139,7 +139,7 @@ namespace Gateway.Test
         [Test]
         public void ReturnUnknownErrorIfJoinRequestErrored()
         {
-            var joinReq = new PlayerJoinRequest("test_op", "", "", null);
+            var joinReq = new PlayerJoinRequest("test_op", "", "", "", "", null);
             joinReq.State = MatchState.Error;
             _memoryStoreClient.Setup(client => client.GetAsync<PlayerJoinRequest>("test_op")).ReturnsAsync(joinReq);
             var deleted = new List<PlayerJoinRequest>();

--- a/services/csharp/Gateway/OperationsServiceImpl.cs
+++ b/services/csharp/Gateway/OperationsServiceImpl.cs
@@ -147,7 +147,7 @@ namespace Gateway
 
                     Reporter.CancelOperationInc();
                     
-                    IDictionary<string, string> eventAttributes = new Dictionary<string, string>
+                    var eventAttributes = new Dictionary<string, string>
                     {
                         { "partyId", partyJoinRequest.Id },
                         { "matchRequestId", partyJoinRequest.MatchRequestId },
@@ -158,12 +158,12 @@ namespace Gateway
                     {
                         if (eventType == "party_match_request_cancelled")
                         {
-                            eventAttributes.Add(new KeyValuePair<string, string>("partyPhase", "Forming")); // Todo: Update currentPhase of Party with a tx
-                            _analytics.Send(eventType, (Dictionary<string, string>) eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
+                            eventAttributes.Add("partyPhase", "Forming"); // Todo: Update currentPhase of Party with a tx
+                            _analytics.Send(eventType, eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
                         }
                         else
                         {
-                            _analytics.Send(eventType, (Dictionary<string, string>) eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
+                            _analytics.Send(eventType, eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
                         }
                     }
 

--- a/services/csharp/Gateway/OperationsServiceImpl.cs
+++ b/services/csharp/Gateway/OperationsServiceImpl.cs
@@ -153,15 +153,9 @@ namespace Gateway
                         { "matchRequestId", partyJoinRequest.MatchRequestId },
                         { "queueType", partyJoinRequest.Type }
                     };
-                    string[] eventTypes = { "party_match_request_cancelled", "player_cancels_match_request" };
-                    foreach (string eventType in eventTypes)
-                    {
-                        if (eventType == "party_match_request_cancelled")
-                        {
-                            eventAttributes.Add("partyPhase", "Forming"); // Todo: Update currentPhase of Party with a tx
-                        }
-                        _analytics.Send(eventType, eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
-                    }
+                    _analytics.Send("player_cancels_match_request", eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
+                    var eventAttributesParty = new Dictionary<string,string>(eventAttributes) { {"partyPhase", "Forming"} };
+                    _analytics.Send("party_match_request_cancelled", eventAttributesParty, partyJoinRequest.Party.LeaderPlayerId);
 
                     foreach (var playerJoinRequest in toDelete.OfType<PlayerJoinRequest>())
                     {

--- a/services/csharp/Gateway/OperationsServiceImpl.cs
+++ b/services/csharp/Gateway/OperationsServiceImpl.cs
@@ -108,7 +108,7 @@ namespace Gateway
             if (!string.Equals(request.Name, playerIdentity))
             {
                 throw new RpcException(new Status(StatusCode.PermissionDenied,
-                    $"Deleting another player's operation is forbidden: {request.Name} vs. {playerIdentity}"));
+                    "Deleting another player's operation is forbidden."));
             }
 
             Log.Information($"Requested cancellation for the party of player identifier {request.Name}.");

--- a/services/csharp/Gateway/OperationsServiceImpl.cs
+++ b/services/csharp/Gateway/OperationsServiceImpl.cs
@@ -159,12 +159,8 @@ namespace Gateway
                         if (eventType == "party_match_request_cancelled")
                         {
                             eventAttributes.Add("partyPhase", "Forming"); // Todo: Update currentPhase of Party with a tx
-                            _analytics.Send(eventType, eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
                         }
-                        else
-                        {
-                            _analytics.Send(eventType, eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
-                        }
+                        _analytics.Send(eventType, eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
                     }
 
                     foreach (var playerJoinRequest in toDelete.OfType<PlayerJoinRequest>())

--- a/services/csharp/Proto/generated/Gateway.cs
+++ b/services/csharp/Proto/generated/Gateway.cs
@@ -26,19 +26,19 @@ namespace Improbable.OnlineServices.Proto.Gateway {
           string.Concat(
             "ChVnYXRld2F5L2dhdGV3YXkucHJvdG8SB2dhdGV3YXkaHGdvb2dsZS9hcGkv",
             "YW5ub3RhdGlvbnMucHJvdG8aI2dvb2dsZS9sb25ncnVubmluZy9vcGVyYXRp",
-            "b25zLnByb3RvIo4BCgtKb2luUmVxdWVzdBIYChBtYXRjaG1ha2luZ190eXBl",
+            "b25zLnByb3RvIqgBCgtKb2luUmVxdWVzdBIYChBtYXRjaG1ha2luZ190eXBl",
             "GAEgASgJEjQKCG1ldGFkYXRhGAIgAygLMiIuZ2F0ZXdheS5Kb2luUmVxdWVz",
-            "dC5NZXRhZGF0YUVudHJ5Gi8KDU1ldGFkYXRhRW50cnkSCwoDa2V5GAEgASgJ",
-            "Eg0KBXZhbHVlGAIgASgJOgI4ASI8CgxKb2luUmVzcG9uc2USEwoLbG9naW5f",
-            "dG9rZW4YASABKAkSFwoPZGVwbG95bWVudF9uYW1lGAIgASgJMmIKDkdhdGV3",
-            "YXlTZXJ2aWNlElAKBEpvaW4SFC5nYXRld2F5LkpvaW5SZXF1ZXN0Gh0uZ29v",
-            "Z2xlLmxvbmdydW5uaW5nLk9wZXJhdGlvbiITgtPkkwINIggvdjEvam9pbjoB",
-            "KkIqqgInSW1wcm9iYWJsZS5PbmxpbmVTZXJ2aWNlcy5Qcm90by5HYXRld2F5",
-            "YgZwcm90bzM="));
+            "dC5NZXRhZGF0YUVudHJ5EhgKEG1hdGNoX3JlcXVlc3RfaWQYAyABKAkaLwoN",
+            "TWV0YWRhdGFFbnRyeRILCgNrZXkYASABKAkSDQoFdmFsdWUYAiABKAk6AjgB",
+            "IjwKDEpvaW5SZXNwb25zZRITCgtsb2dpbl90b2tlbhgBIAEoCRIXCg9kZXBs",
+            "b3ltZW50X25hbWUYAiABKAkyYgoOR2F0ZXdheVNlcnZpY2USUAoESm9pbhIU",
+            "LmdhdGV3YXkuSm9pblJlcXVlc3QaHS5nb29nbGUubG9uZ3J1bm5pbmcuT3Bl",
+            "cmF0aW9uIhOC0+STAg0iCC92MS9qb2luOgEqQiqqAidJbXByb2JhYmxlLk9u",
+            "bGluZVNlcnZpY2VzLlByb3RvLkdhdGV3YXliBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.LongRunning.OperationsReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, new pbr::GeneratedClrTypeInfo[] {
-            new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.OnlineServices.Proto.Gateway.JoinRequest), global::Improbable.OnlineServices.Proto.Gateway.JoinRequest.Parser, new[]{ "MatchmakingType", "Metadata" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.OnlineServices.Proto.Gateway.JoinRequest), global::Improbable.OnlineServices.Proto.Gateway.JoinRequest.Parser, new[]{ "MatchmakingType", "Metadata", "MatchRequestId" }, null, null, new pbr::GeneratedClrTypeInfo[] { null, }),
             new pbr::GeneratedClrTypeInfo(typeof(global::Improbable.OnlineServices.Proto.Gateway.JoinResponse), global::Improbable.OnlineServices.Proto.Gateway.JoinResponse.Parser, new[]{ "LoginToken", "DeploymentName" }, null, null, null)
           }));
     }
@@ -73,6 +73,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
     public JoinRequest(JoinRequest other) : this() {
       matchmakingType_ = other.matchmakingType_;
       metadata_ = other.metadata_.Clone();
+      matchRequestId_ = other.matchRequestId_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -102,6 +103,17 @@ namespace Improbable.OnlineServices.Proto.Gateway {
       get { return metadata_; }
     }
 
+    /// <summary>Field number for the "match_request_id" field.</summary>
+    public const int MatchRequestIdFieldNumber = 3;
+    private string matchRequestId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    public string MatchRequestId {
+      get { return matchRequestId_; }
+      set {
+        matchRequestId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     public override bool Equals(object other) {
       return Equals(other as JoinRequest);
@@ -117,6 +129,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
       }
       if (MatchmakingType != other.MatchmakingType) return false;
       if (!Metadata.Equals(other.Metadata)) return false;
+      if (MatchRequestId != other.MatchRequestId) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -125,6 +138,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
       int hash = 1;
       if (MatchmakingType.Length != 0) hash ^= MatchmakingType.GetHashCode();
       hash ^= Metadata.GetHashCode();
+      if (MatchRequestId.Length != 0) hash ^= MatchRequestId.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -143,6 +157,10 @@ namespace Improbable.OnlineServices.Proto.Gateway {
         output.WriteString(MatchmakingType);
       }
       metadata_.WriteTo(output, _map_metadata_codec);
+      if (MatchRequestId.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(MatchRequestId);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -155,6 +173,9 @@ namespace Improbable.OnlineServices.Proto.Gateway {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(MatchmakingType);
       }
       size += metadata_.CalculateSize(_map_metadata_codec);
+      if (MatchRequestId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(MatchRequestId);
+      }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -170,6 +191,9 @@ namespace Improbable.OnlineServices.Proto.Gateway {
         MatchmakingType = other.MatchmakingType;
       }
       metadata_.Add(other.metadata_);
+      if (other.MatchRequestId.Length != 0) {
+        MatchRequestId = other.MatchRequestId;
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -187,6 +211,10 @@ namespace Improbable.OnlineServices.Proto.Gateway {
           }
           case 18: {
             metadata_.AddEntriesFrom(input, _map_metadata_codec);
+            break;
+          }
+          case 26: {
+            MatchRequestId = input.ReadString();
             break;
           }
         }

--- a/services/proto/gateway/gateway.proto
+++ b/services/proto/gateway/gateway.proto
@@ -10,6 +10,7 @@ option csharp_namespace = "Improbable.OnlineServices.Proto.Gateway";
 message JoinRequest {
   string matchmaking_type = 1;
   map<string, string> metadata = 2;
+  string match_request_id = 3;
 }
 
 message JoinResponse {


### PR DESCRIPTION
This PR instruments the Gateway, and includes some changes to the data model so that `partyJoinRequests` contain a `matchRequestId`, and a playerJoinRequest contains a `partyId` and a `matchRequestId` - which facilitates better tracking.

Hook overview: https://docs.google.com/spreadsheets/d/1nlEWy5b97IMdpmHXWLrv5ZtuU3YnU3Ba6-JmVBxB238/edit#gid=0 (where `eventSource` = `gateway_gateway`).