### PR TITLE
explicitly set the default match tag used by matcher

### DIFF
--- a/services/k8s/config.yaml
+++ b/services/k8s/config.yaml
@@ -7,4 +7,3 @@ data:
   redis.connection-string: "{{your_redis_host}}:6379"
   spatialos.project: "{{your_spatialos_project_name}}"
   playfab.title: "{{your_playfab_title_id}}"
-  matcher.default-tag: "match"

--- a/services/k8s/config.yaml
+++ b/services/k8s/config.yaml
@@ -7,3 +7,4 @@ data:
   redis.connection-string: "{{your_redis_host}}:6379"
   spatialos.project: "{{your_spatialos_project_name}}"
   playfab.title: "{{your_playfab_title_id}}"
+  matcher.default-tag: "match"

--- a/services/k8s/sample-matcher/deployment.yaml
+++ b/services/k8s/sample-matcher/deployment.yaml
@@ -33,5 +33,10 @@ spec:
             configMapKeyRef:
               name: online-services-config
               key: spatialos.project
+        - name: MATCH_TAG
+          valueFrom:
+            configMapKeyRef:
+              name: online-services-config
+              key: matcher.default-tag
         - name: GATEWAY_SERVICE_TARGET
           value: "gateway-internal.default.svc.cluster.local:80"

--- a/services/k8s/sample-matcher/deployment.yaml
+++ b/services/k8s/sample-matcher/deployment.yaml
@@ -34,9 +34,6 @@ spec:
               name: online-services-config
               key: spatialos.project
         - name: MATCH_TAG
-          valueFrom:
-            configMapKeyRef:
-              name: online-services-config
-              key: matcher.default-tag
+          value: "match"
         - name: GATEWAY_SERVICE_TARGET
           value: "gateway-internal.default.svc.cluster.local:80"


### PR DESCRIPTION
Did a QA pass today re-rolling out all services. I wanted to try using a different queue type than `match` and see whether the system still worked using the SampleClient.

I updated:
- The deployment pool setup [here](https://github.com/spatialos/online-services/blob/master/services/k8s/deployment-pool/deployment.yaml#L56
).
- The SampleClient [here](https://github.com/spatialos/online-services/blob/master/services/csharp/SampleClient/Program.cs#L104).

This wasn't enough, because I forgot the Matcher is defaulting to `match` unless you pass it a `MATCH_TAG` environment variable through its k8s configuration file. This wasn't obvious because our template isn't doing this, and is instead currently relying on [this default](https://github.com/spatialos/online-services/blob/master/services/csharp/SampleMatcher/Matcher.cs#L23).

Suggest we add this value in our general configMap and capture it in the k8s config file of the sample matcher. This way it's more obvious this value also needs to be updated! 