### PR TITLE
added enablement of cloud function api to terraform

### DIFF
--- a/services/terraform/services.tf
+++ b/services/terraform/services.tf
@@ -41,3 +41,9 @@ resource "google_project_service" "iam" {
   service            = "iam.googleapis.com"
   disable_on_destroy = false
 }
+
+resource "google_project_service" "cloudfunction" {
+  project            = "${var.gcloud_project}"
+  service            = "cloudfunctions.googleapis.com"
+  disable_on_destroy = false
+}


### PR DESCRIPTION
Encountered a small issue when deploying the Online Services including analytics in a fresh project, forgot to enable the Cloud Function API with Terraform.