### PR TITLE
Upgrade gRPC packages across solution to 1.22.1

### DIFF
--- a/services/csharp/Base.Server/Base.Server.csproj
+++ b/services/csharp/Base.Server/Base.Server.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="2.2.0" />
-    <PackageReference Include="Grpc.Core" Version="1.19.0" />
+    <PackageReference Include="Grpc.Core" Version="2.24.0" />
     <PackageReference Include="LibLog" Version="5.0.3" />
     <PackageReference Include="NetGrpcPrometheus" Version="1.0.14" />
   </ItemGroup>

--- a/services/csharp/Base.Server/Base.Server.csproj
+++ b/services/csharp/Base.Server/Base.Server.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Google.Cloud.Logging.V2" Version="2.2.0" />
-    <PackageReference Include="Grpc.Core" Version="2.24.0" />
+    <PackageReference Include="Grpc.Core" Version="1.22.1" />
     <PackageReference Include="LibLog" Version="5.0.3" />
     <PackageReference Include="NetGrpcPrometheus" Version="1.0.14" />
   </ItemGroup>

--- a/services/csharp/Common/Common.csproj
+++ b/services/csharp/Common/Common.csproj
@@ -14,7 +14,7 @@
     <Copyright>2019 Improbable Worlds Ltd.</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="2.24.0" />
+    <PackageReference Include="Grpc.Core" Version="1.22.1" />
     <PackageReference Include="Improbable.SpatialOS.Platform" Version="14.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/csharp/Common/Common.csproj
+++ b/services/csharp/Common/Common.csproj
@@ -14,7 +14,7 @@
     <Copyright>2019 Improbable Worlds Ltd.</Copyright>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Grpc.Core" Version="1.19.0" />
+    <PackageReference Include="Grpc.Core" Version="2.24.0" />
     <PackageReference Include="Improbable.SpatialOS.Platform" Version="14.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/csharp/Common/Common.nuspec
+++ b/services/csharp/Common/Common.nuspec
@@ -14,7 +14,7 @@
     <copyright>2019 Improbable Worlds Ltd.</copyright>
     <dependencies>
       <group targetFramework=".NETCoreApp2.1">
-        <dependency id="Grpc.Core" version="1.19.0" exclude="Build,Analyzers" />
+        <dependency id="Grpc.Core" version="1.22.1" exclude="Build,Analyzers" />
         <dependency id="Improbable.SpatialOS.Platform" version="14.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/services/csharp/Proto/Proto.csproj
+++ b/services/csharp/Proto/Proto.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.5.0" />
     <PackageReference Include="Google.LongRunning" Version="1.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
-    <PackageReference Include="Grpc.Core" Version="1.19.0" />
-    <PackageReference Include="Grpc.Tools" Version="1.19.0">
+    <PackageReference Include="Grpc.Core" Version="2.24.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.24.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/services/csharp/Proto/Proto.csproj
+++ b/services/csharp/Proto/Proto.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.5.0" />
     <PackageReference Include="Google.LongRunning" Version="1.0.0" />
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
-    <PackageReference Include="Grpc.Core" Version="2.24.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.24.0">
+    <PackageReference Include="Grpc.Core" Version="1.22.1" />
+    <PackageReference Include="Grpc.Tools" Version="1.22.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/services/csharp/Proto/generated/GatewayGrpc.cs
+++ b/services/csharp/Proto/generated/GatewayGrpc.cs
@@ -44,7 +44,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
     {
       /// <summary>Creates a new client for GatewayService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public GatewayServiceClient(grpc::ChannelBase channel) : base(channel)
+      public GatewayServiceClient(grpc::Channel channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for GatewayService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/GatewayGrpc.cs
+++ b/services/csharp/Proto/generated/GatewayGrpc.cs
@@ -29,6 +29,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
     }
 
     /// <summary>Base class for server-side implementations of GatewayService</summary>
+    [grpc::BindServiceMethod(typeof(GatewayService), "BindService")]
     public abstract partial class GatewayServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::Google.LongRunning.Operation> Join(global::Improbable.OnlineServices.Proto.Gateway.JoinRequest request, grpc::ServerCallContext context)
@@ -43,7 +44,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
     {
       /// <summary>Creates a new client for GatewayService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public GatewayServiceClient(grpc::Channel channel) : base(channel)
+      public GatewayServiceClient(grpc::ChannelBase channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for GatewayService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/GatewayInternal.cs
+++ b/services/csharp/Proto/generated/GatewayInternal.cs
@@ -230,7 +230,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
       }
       if (other.party_ != null) {
         if (party_ == null) {
-          party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+          Party = new global::Improbable.OnlineServices.Proto.Party.Party();
         }
         Party.MergeFrom(other.Party);
       }
@@ -256,13 +256,13 @@ namespace Improbable.OnlineServices.Proto.Gateway {
             break;
           case 10: {
             if (party_ == null) {
-              party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+              Party = new global::Improbable.OnlineServices.Proto.Party.Party();
             }
-            input.ReadMessage(party_);
+            input.ReadMessage(Party);
             break;
           }
           case 16: {
-            result_ = (global::Improbable.OnlineServices.Proto.Gateway.Assignment.Types.Result) input.ReadEnum();
+            Result = (global::Improbable.OnlineServices.Proto.Gateway.Assignment.Types.Result) input.ReadEnum();
             break;
           }
           case 26: {
@@ -794,7 +794,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
       }
       if (other.party_ != null) {
         if (party_ == null) {
-          party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+          Party = new global::Improbable.OnlineServices.Proto.Party.Party();
         }
         Party.MergeFrom(other.Party);
       }
@@ -812,9 +812,9 @@ namespace Improbable.OnlineServices.Proto.Gateway {
             break;
           case 10: {
             if (party_ == null) {
-              party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+              Party = new global::Improbable.OnlineServices.Proto.Party.Party();
             }
-            input.ReadMessage(party_);
+            input.ReadMessage(Party);
             break;
           }
           case 18: {

--- a/services/csharp/Proto/generated/GatewayInternalGrpc.cs
+++ b/services/csharp/Proto/generated/GatewayInternalGrpc.cs
@@ -58,7 +58,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
     {
       /// <summary>Creates a new client for GatewayInternalService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public GatewayInternalServiceClient(grpc::ChannelBase channel) : base(channel)
+      public GatewayInternalServiceClient(grpc::Channel channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for GatewayInternalService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/GatewayInternalGrpc.cs
+++ b/services/csharp/Proto/generated/GatewayInternalGrpc.cs
@@ -38,6 +38,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
     }
 
     /// <summary>Base class for server-side implementations of GatewayInternalService</summary>
+    [grpc::BindServiceMethod(typeof(GatewayInternalService), "BindService")]
     public abstract partial class GatewayInternalServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::Improbable.OnlineServices.Proto.Gateway.AssignDeploymentsResponse> AssignDeployments(global::Improbable.OnlineServices.Proto.Gateway.AssignDeploymentsRequest request, grpc::ServerCallContext context)
@@ -57,7 +58,7 @@ namespace Improbable.OnlineServices.Proto.Gateway {
     {
       /// <summary>Creates a new client for GatewayInternalService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public GatewayInternalServiceClient(grpc::Channel channel) : base(channel)
+      public GatewayInternalServiceClient(grpc::ChannelBase channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for GatewayInternalService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/Invite.cs
+++ b/services/csharp/Proto/generated/Invite.cs
@@ -332,7 +332,7 @@ namespace Improbable.OnlineServices.Proto.Invite {
             break;
           }
           case 48: {
-            currentStatus_ = (global::Improbable.OnlineServices.Proto.Invite.Invite.Types.Status) input.ReadEnum();
+            CurrentStatus = (global::Improbable.OnlineServices.Proto.Invite.Invite.Types.Status) input.ReadEnum();
             break;
           }
         }
@@ -970,7 +970,7 @@ namespace Improbable.OnlineServices.Proto.Invite {
       }
       if (other.updatedInvite_ != null) {
         if (updatedInvite_ == null) {
-          updatedInvite_ = new global::Improbable.OnlineServices.Proto.Invite.Invite();
+          UpdatedInvite = new global::Improbable.OnlineServices.Proto.Invite.Invite();
         }
         UpdatedInvite.MergeFrom(other.UpdatedInvite);
       }
@@ -987,9 +987,9 @@ namespace Improbable.OnlineServices.Proto.Invite {
             break;
           case 10: {
             if (updatedInvite_ == null) {
-              updatedInvite_ = new global::Improbable.OnlineServices.Proto.Invite.Invite();
+              UpdatedInvite = new global::Improbable.OnlineServices.Proto.Invite.Invite();
             }
-            input.ReadMessage(updatedInvite_);
+            input.ReadMessage(UpdatedInvite);
             break;
           }
         }
@@ -1105,7 +1105,7 @@ namespace Improbable.OnlineServices.Proto.Invite {
       }
       if (other.invite_ != null) {
         if (invite_ == null) {
-          invite_ = new global::Improbable.OnlineServices.Proto.Invite.Invite();
+          Invite = new global::Improbable.OnlineServices.Proto.Invite.Invite();
         }
         Invite.MergeFrom(other.Invite);
       }
@@ -1122,9 +1122,9 @@ namespace Improbable.OnlineServices.Proto.Invite {
             break;
           case 10: {
             if (invite_ == null) {
-              invite_ = new global::Improbable.OnlineServices.Proto.Invite.Invite();
+              Invite = new global::Improbable.OnlineServices.Proto.Invite.Invite();
             }
-            input.ReadMessage(invite_);
+            input.ReadMessage(Invite);
             break;
           }
         }
@@ -1369,7 +1369,7 @@ namespace Improbable.OnlineServices.Proto.Invite {
       }
       if (other.invite_ != null) {
         if (invite_ == null) {
-          invite_ = new global::Improbable.OnlineServices.Proto.Invite.Invite();
+          Invite = new global::Improbable.OnlineServices.Proto.Invite.Invite();
         }
         Invite.MergeFrom(other.Invite);
       }
@@ -1386,9 +1386,9 @@ namespace Improbable.OnlineServices.Proto.Invite {
             break;
           case 10: {
             if (invite_ == null) {
-              invite_ = new global::Improbable.OnlineServices.Proto.Invite.Invite();
+              Invite = new global::Improbable.OnlineServices.Proto.Invite.Invite();
             }
-            input.ReadMessage(invite_);
+            input.ReadMessage(Invite);
             break;
           }
         }

--- a/services/csharp/Proto/generated/InviteGrpc.cs
+++ b/services/csharp/Proto/generated/InviteGrpc.cs
@@ -106,7 +106,7 @@ namespace Improbable.OnlineServices.Proto.Invite {
     {
       /// <summary>Creates a new client for InviteService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public InviteServiceClient(grpc::ChannelBase channel) : base(channel)
+      public InviteServiceClient(grpc::Channel channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for InviteService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/InviteGrpc.cs
+++ b/services/csharp/Proto/generated/InviteGrpc.cs
@@ -65,6 +65,7 @@ namespace Improbable.OnlineServices.Proto.Invite {
     }
 
     /// <summary>Base class for server-side implementations of InviteService</summary>
+    [grpc::BindServiceMethod(typeof(InviteService), "BindService")]
     public abstract partial class InviteServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::Improbable.OnlineServices.Proto.Invite.CreateInviteResponse> CreateInvite(global::Improbable.OnlineServices.Proto.Invite.CreateInviteRequest request, grpc::ServerCallContext context)
@@ -105,7 +106,7 @@ namespace Improbable.OnlineServices.Proto.Invite {
     {
       /// <summary>Creates a new client for InviteService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public InviteServiceClient(grpc::Channel channel) : base(channel)
+      public InviteServiceClient(grpc::ChannelBase channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for InviteService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/Party.cs
+++ b/services/csharp/Proto/generated/Party.cs
@@ -361,7 +361,7 @@ namespace Improbable.OnlineServices.Proto.Party {
             break;
           }
           case 56: {
-            currentPhase_ = (global::Improbable.OnlineServices.Proto.Party.Party.Types.Phase) input.ReadEnum();
+            CurrentPhase = (global::Improbable.OnlineServices.Proto.Party.Party.Types.Phase) input.ReadEnum();
             break;
           }
         }
@@ -898,7 +898,7 @@ namespace Improbable.OnlineServices.Proto.Party {
       }
       if (other.party_ != null) {
         if (party_ == null) {
-          party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+          Party = new global::Improbable.OnlineServices.Proto.Party.Party();
         }
         Party.MergeFrom(other.Party);
       }
@@ -915,9 +915,9 @@ namespace Improbable.OnlineServices.Proto.Party {
             break;
           case 10: {
             if (party_ == null) {
-              party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+              Party = new global::Improbable.OnlineServices.Proto.Party.Party();
             }
-            input.ReadMessage(party_);
+            input.ReadMessage(Party);
             break;
           }
         }
@@ -1364,7 +1364,7 @@ namespace Improbable.OnlineServices.Proto.Party {
       }
       if (other.party_ != null) {
         if (party_ == null) {
-          party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+          Party = new global::Improbable.OnlineServices.Proto.Party.Party();
         }
         Party.MergeFrom(other.Party);
       }
@@ -1381,9 +1381,9 @@ namespace Improbable.OnlineServices.Proto.Party {
             break;
           case 10: {
             if (party_ == null) {
-              party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+              Party = new global::Improbable.OnlineServices.Proto.Party.Party();
             }
-            input.ReadMessage(party_);
+            input.ReadMessage(Party);
             break;
           }
         }
@@ -1931,7 +1931,7 @@ namespace Improbable.OnlineServices.Proto.Party {
       }
       if (other.updatedParty_ != null) {
         if (updatedParty_ == null) {
-          updatedParty_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+          UpdatedParty = new global::Improbable.OnlineServices.Proto.Party.Party();
         }
         UpdatedParty.MergeFrom(other.UpdatedParty);
       }
@@ -1948,9 +1948,9 @@ namespace Improbable.OnlineServices.Proto.Party {
             break;
           case 18: {
             if (updatedParty_ == null) {
-              updatedParty_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+              UpdatedParty = new global::Improbable.OnlineServices.Proto.Party.Party();
             }
-            input.ReadMessage(updatedParty_);
+            input.ReadMessage(UpdatedParty);
             break;
           }
         }
@@ -2066,7 +2066,7 @@ namespace Improbable.OnlineServices.Proto.Party {
       }
       if (other.party_ != null) {
         if (party_ == null) {
-          party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+          Party = new global::Improbable.OnlineServices.Proto.Party.Party();
         }
         Party.MergeFrom(other.Party);
       }
@@ -2083,9 +2083,9 @@ namespace Improbable.OnlineServices.Proto.Party {
             break;
           case 10: {
             if (party_ == null) {
-              party_ = new global::Improbable.OnlineServices.Proto.Party.Party();
+              Party = new global::Improbable.OnlineServices.Proto.Party.Party();
             }
-            input.ReadMessage(party_);
+            input.ReadMessage(Party);
             break;
           }
         }

--- a/services/csharp/Proto/generated/PartyGrpc.cs
+++ b/services/csharp/Proto/generated/PartyGrpc.cs
@@ -135,7 +135,7 @@ namespace Improbable.OnlineServices.Proto.Party {
     {
       /// <summary>Creates a new client for PartyService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public PartyServiceClient(grpc::ChannelBase channel) : base(channel)
+      public PartyServiceClient(grpc::Channel channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for PartyService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/PartyGrpc.cs
+++ b/services/csharp/Proto/generated/PartyGrpc.cs
@@ -83,6 +83,7 @@ namespace Improbable.OnlineServices.Proto.Party {
     }
 
     /// <summary>Base class for server-side implementations of PartyService</summary>
+    [grpc::BindServiceMethod(typeof(PartyService), "BindService")]
     public abstract partial class PartyServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::Improbable.OnlineServices.Proto.Party.CreatePartyResponse> CreateParty(global::Improbable.OnlineServices.Proto.Party.CreatePartyRequest request, grpc::ServerCallContext context)
@@ -134,7 +135,7 @@ namespace Improbable.OnlineServices.Proto.Party {
     {
       /// <summary>Creates a new client for PartyService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public PartyServiceClient(grpc::Channel channel) : base(channel)
+      public PartyServiceClient(grpc::ChannelBase channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for PartyService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/PlayfabGrpc.cs
+++ b/services/csharp/Proto/generated/PlayfabGrpc.cs
@@ -44,7 +44,7 @@ namespace Improbable.OnlineServices.Proto.Auth.PlayFab {
     {
       /// <summary>Creates a new client for AuthService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public AuthServiceClient(grpc::ChannelBase channel) : base(channel)
+      public AuthServiceClient(grpc::Channel channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for AuthService that uses a custom <c>CallInvoker</c>.</summary>

--- a/services/csharp/Proto/generated/PlayfabGrpc.cs
+++ b/services/csharp/Proto/generated/PlayfabGrpc.cs
@@ -29,6 +29,7 @@ namespace Improbable.OnlineServices.Proto.Auth.PlayFab {
     }
 
     /// <summary>Base class for server-side implementations of AuthService</summary>
+    [grpc::BindServiceMethod(typeof(AuthService), "BindService")]
     public abstract partial class AuthServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::Improbable.OnlineServices.Proto.Auth.PlayFab.ExchangePlayFabTokenResponse> ExchangePlayFabToken(global::Improbable.OnlineServices.Proto.Auth.PlayFab.ExchangePlayFabTokenRequest request, grpc::ServerCallContext context)
@@ -43,7 +44,7 @@ namespace Improbable.OnlineServices.Proto.Auth.PlayFab {
     {
       /// <summary>Creates a new client for AuthService</summary>
       /// <param name="channel">The channel to use to make remote calls.</param>
-      public AuthServiceClient(grpc::Channel channel) : base(channel)
+      public AuthServiceClient(grpc::ChannelBase channel) : base(channel)
       {
       }
       /// <summary>Creates a new client for AuthService that uses a custom <c>CallInvoker</c>.</summary>


### PR DESCRIPTION
Upgrade `Grpc.Core` and `Grpc.Tools` across solution to 2.24.0. This is equivalent to gRPC version 1.24.0; the [major version bump](https://github.com/grpc/proposal/blob/master/L57-csharp-new-major-version.md) was caused by a breaking changed needed to support .NET Core 3.0.