### PR TITLE
Update builder queue

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -5,7 +5,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "scaler_version=2"
-    - "queue=${CI_BUILDER_QUEUE:-v3-1559657210-cbf47979a9aab331-------z}"
+    - "queue=${CI_BUILDER_QUEUE:-v3-1570545580-fd51227400924f3d-------z}"
   timeout_in_minutes: 5
   retry:
     automatic:
@@ -32,6 +32,8 @@ steps:
     timeout_in_minutes: 15
     artifact_paths:
       - "*.xml"
+    depends_on:
+      - step: "build"
 
   - label: "integration tests"
     id: "integration-test"
@@ -40,6 +42,8 @@ steps:
     timeout_in_minutes: 15
     artifact_paths:
       - "*.xml"
+    depends_on:
+      - step: "build"
 
   - label: "dotnet format"
     id: "format"


### PR DESCRIPTION
Update to use the combined 2.2 and 3.0 .NET builder.

Also ensure the unit and integration tests only run after the initial build phase completes, to mitigate Nuget clashes.