### PR TITLE
Give service accounts package read permissions by default.

### DIFF
--- a/tools/ServiceAccountCLI/Program.cs
+++ b/tools/ServiceAccountCLI/Program.cs
@@ -60,13 +60,19 @@ namespace ServiceAccountCLI
                 Verbs = {projectPermissionVerbs}
             };
 
+            var packagePermissions = new Permission
+            {
+                Parts = {new RepeatedField<string> {"srv", "pkg"}},
+                Verbs = {new RepeatedField<Permission.Types.Verb> {Permission.Types.Verb.Read}}
+            };
+
             var bundlePermissions = new Permission
             {
                 Parts = {new RepeatedField<string> {"srv", "bundles"}},
                 Verbs = {new RepeatedField<Permission.Types.Verb> {Permission.Types.Verb.Read}}
             };
 
-            var permissions = new RepeatedField<Permission> {projectPermission, bundlePermissions};
+            var permissions = new RepeatedField<Permission> {projectPermission, bundlePermissions, packagePermissions};
 
             if (opts.MetricsRead)
             {

--- a/tools/ServiceAccountCLI/Program.cs
+++ b/tools/ServiceAccountCLI/Program.cs
@@ -4,6 +4,7 @@ using System.Text;
 using CommandLine;
 using Google.Protobuf.Collections;
 using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
 using Improbable.SpatialOS.Platform.Common;
 using Improbable.SpatialOS.ServiceAccount.V1Alpha1;
 
@@ -16,12 +17,24 @@ namespace ServiceAccountCLI
         
         static int Main(string[] args)
         {
-            return Parser.Default.ParseArguments<CreateOptions, ListOptions, DeleteOptions>(args).MapResult(
-                (CreateOptions opts) => CreateServiceAccount(opts),
-                (ListOptions opts) => ListServiceAccounts(opts),
-                (DeleteOptions opts) => DeleteServiceAccount(opts),
-                 errs => 1
+            try
+            {
+                return Parser.Default.ParseArguments<CreateOptions, ListOptions, DeleteOptions>(args).MapResult(
+                    (CreateOptions opts) => CreateServiceAccount(opts),
+                    (ListOptions opts) => ListServiceAccounts(opts),
+                    (DeleteOptions opts) => DeleteServiceAccount(opts),
+                    errs => 1
                 );
+            }
+            catch (RpcException exp)
+            {
+                if (exp.Status.StatusCode == StatusCode.Unauthenticated)
+                {
+                    Console.WriteLine("Authentication failed." +
+                                      "You may need to run 'spatial auth login' to ensure your credentials are up to date.");
+                }
+                throw;
+            }
         }
 
         private static int CreateServiceAccount(CreateOptions opts)

--- a/tools/ServiceAccountCLI/README.md
+++ b/tools/ServiceAccountCLI/README.md
@@ -1,3 +1,3 @@
 # The SpatialOS Online Services: Service account CLI tool
 
-See the documentation [Online Services section of the SpatialOS documentation website](https://docs.improbable.io/metagame/latest), specifically the [Service account CLI tool documentation](https://docs.improbable.io/metagame/latest)
+See the documentation [Online Services section of the SpatialOS documentation website](https://docs.improbable.io/metagame/latest), specifically the [Service account CLI tool documentation](https://docs.improbable.io/metagame/latest/content/workflows/service-account-cli).


### PR DESCRIPTION
# What?

Adds read permission for `srv/pkg` by default to created service accounts.
This permission allows for retrieving packages (e.g. worker SDKs, schema etc.), typically used for building SpatialOS projects.

It is set by default as opposed to exposing it as a flag because:
* The permission isn't sensitive
* This is consistent with how we handle read permissions for `srv/bundle` which allows downloading versions of the runtime (required for running SpatialOS projects).

# Why?

Service accounts generated by this tool are not only being used for running online services but also for building and running SpatialOS projects in CI.

# Testing

Verified by generating a token and using it to retrieve packages via `spatial package get`.

# Drive-Bys

* Fix a link in the docs
* Print a message suggesting to users to try running `spatial auth login` on an authentication error as expired tokens are the most likely culprit.

