### PR TITLE
Instrument CancelJoin RPC

### DIFF
--- a/services/csharp/Gateway/GatewayServiceImpl.cs
+++ b/services/csharp/Gateway/GatewayServiceImpl.cs
@@ -229,6 +229,27 @@ namespace Gateway
                     }
 
                     Reporter.CancelJoinInc();
+
+                    var eventAttributes = new Dictionary<string, string>
+                    {
+                        { "partyId", partyJoinRequest.Id },
+                        { "matchRequestId", partyJoinRequest.MatchRequestId },
+                        { "queueType", partyJoinRequest.Type }
+                    };
+                    _analytics.Send("player_cancels_match_request", eventAttributes, partyJoinRequest.Party.LeaderPlayerId);
+                    var eventAttributesParty = new Dictionary<string, string>(eventAttributes) { { "partyPhase", "Forming" } };
+                    _analytics.Send("party_match_request_cancelled", eventAttributesParty, partyJoinRequest.Party.LeaderPlayerId);
+
+                    foreach (var playerJoinRequest in toDelete.OfType<PlayerJoinRequest>())
+                    {
+                        _analytics.Send("player_left_cancelled_match_request", new Dictionary<string, string>
+                        {
+                            { "partyId", playerJoinRequest.PartyId },
+                            { "matchRequestId", playerJoinRequest.MatchRequestId },
+                            { "queueType", playerJoinRequest.Type }
+                        }, playerJoinRequest.Id);
+                    }
+
                     return new CancelJoinResponse();
                 }
                 catch (EntryNotFoundException exception)


### PR DESCRIPTION
I've just lifted this wholesale from the old `OperationsService`. The `GetOperation` RPC was not instrumented so I haven't touched the `GetJoinStatus`.