### PR TITLE
restricted SA GCS access to read/write

### DIFF
--- a/services/terraform/module-analytics/service-accounts-endpoint.tf
+++ b/services/terraform/module-analytics/service-accounts-endpoint.tf
@@ -7,16 +7,22 @@ resource "google_service_account" "analytics_gcs_writer_sa" {
   display_name = "Analytics GCS Writer"
 }
 
-# Grant the Service Account Admin rights to our specific GCS bucket.
+# Grant the Service Account write rights to our specific GCS bucket.
+variable "bucket_write_roles" {
+  type        = list(string)
+  default     = ["roles/storage.legacyBucketReader", "roles/storage.objectCreator"]
+}
+
 resource "google_storage_bucket_iam_member" "analytics_gcs_writer_binding" {
 
   # Ensures the analytics_bucket is created before this operation is attempted.
   depends_on = [
     google_storage_bucket.analytics_bucket
   ]
+  count  = length(var.bucket_write_roles)
 
   bucket = "${var.gcloud_project}-analytics"
-  role   = "roles/storage.admin"
+  role   = var.bucket_write_roles[count.index]
   member = "serviceAccount:${google_service_account.analytics_gcs_writer_sa.email}"
 }
 

--- a/services/terraform/module-analytics/service-accounts-function.tf
+++ b/services/terraform/module-analytics/service-accounts-function.tf
@@ -24,9 +24,22 @@ resource "google_project_iam_member" "bq_role" {
   member = "serviceAccount:${google_service_account.cloud_function_gcs_to_bq.email}"
 }
 
-# Add the roles/storage.admin role.
-resource "google_project_iam_member" "storage_role" {
-  role   = "roles/storage.admin"
+# Grant the Service Account read rights to our specific GCS bucket.
+variable "bucket_read_roles" {
+  type        = list(string)
+  default     = ["roles/storage.legacyBucketReader", "roles/storage.objectViewer"]
+}
+
+resource "google_storage_bucket_iam_member" "analytics_function_to_bq_binding" {
+
+  # Ensures the analytics_bucket is created before this operation is attempted.
+  depends_on = [
+    google_storage_bucket.analytics_bucket
+  ]
+  count  = length(var.bucket_read_roles)
+
+  bucket = "${var.gcloud_project}-analytics"
+  role   = var.bucket_read_roles[count.index]
   member = "serviceAccount:${google_service_account.cloud_function_gcs_to_bq.email}"
 }
 


### PR DESCRIPTION
This PR tightens the GCS permissions for two analytics service-accounts:

* The service account used by the Endpoint can now only _write_ into GCS.
* The service account used by the Cloud Function can now only _read_ from GCS.

Instead of going down the path creating [custom roles](https://cloud.google.com/iam/docs/creating-custom-roles), I decided to stick with the [readily available roles](https://cloud.google.com/storage/docs/access-control/iam-roles) for simplicity, although this does mean I had to add two roles. In particular `roles/storage.legacyBucketReader` was necessary to provide the `storage.buckets.get` permission.

Integration test succeeded:

```sql
SELECT * FROM `logical-flame-194710.events.events_function_native`
WHERE event_class = 'permission-test';
```