### PR TITLE
optimized cloud function to be able to use smallest template

### DIFF
--- a/services/python/analytics-pipeline/src/function/main.py
+++ b/services/python/analytics-pipeline/src/function/main.py
@@ -56,6 +56,7 @@ def ingest_into_native_bigquery_storage(data, context):
 
     # Parse list:
     malformed, failed_insertion = False, False
+    # We use generators in order to save memory usage, allowing the Cloud Function to use the smallest capacity template:
     for chunk in generator_chunk(generator_split(data, '\n'), 1000):
         events_batch_function, events_batch_debug = [], []
         for event_tuple in generator_load_json(chunk):
@@ -100,6 +101,7 @@ def ingest_into_native_bigquery_storage(data, context):
                 failed_insertion = True
             malformed = True
 
+    # We only `raise` now because further iterations of the execution loop could have still succeeded:
     if failed_insertion and malformed:
         raise Exception(f'Failed to insert records into BigQuery, inspect logs! Non-JSON data present in gs://{bucket_name}/{object_location}')
     if failed_insertion:

--- a/services/python/analytics-pipeline/src/function/main.py
+++ b/services/python/analytics-pipeline/src/function/main.py
@@ -50,7 +50,7 @@ def ingest_into_native_bigquery_storage(data, context):
         data = bucket.get_blob(object_location).download_as_string().decode('utf8')
     except UnicodeDecodeError:
         print('Automatic decompressive transcoding failed, unzipping content..')
-        data = gunzip_bytes_obj(bucket.get_blob(object_location).download_as_string())
+        data = gunzip_bytes_obj(bucket.get_blob(object_location).download_as_string()).decode('utf-8')
     except Exception:
         raise Exception(f'Could not retrieve file gs://{bucket_name}/{object_location} from GCS!')
 

--- a/services/python/analytics-pipeline/src/function/main.py
+++ b/services/python/analytics-pipeline/src/function/main.py
@@ -1,6 +1,6 @@
-# Python 3.7
 
-from common.functions import try_parse_json, get_dict_value, cast_to_unix_timestamp, format_event_list, gunzip_bytes_obj
+from common.functions import get_dict_value, cast_to_unix_timestamp, format_event_list, \
+  gunzip_bytes_obj, generator_split, generator_chunk, generator_load_json
 from common.bigquery import source_bigquery_assets, generate_bigquery_assets
 from google.cloud import bigquery, storage
 
@@ -23,80 +23,88 @@ def ingest_into_native_bigquery_storage(data, context):
 
     # Source required datasets & tables:
     bigquery_asset_list = [
-      ('logs', 'events_logs_function_native', 'event_ds'),
-      ('logs', 'events_debug_function_native', 'event_ds'),
-      ('logs', 'events_logs_dataflow_backfill', 'event_ds'),
-      ('events', 'events_function_native', 'event_timestamp')]
+        # Schema: (dataset, table_name, partition_column)
+        ('logs', 'events_logs_function_native', 'event_ds'),
+        ('logs', 'events_debug_function_native', 'event_ds'),
+        ('logs', 'events_logs_dataflow_backfill', 'event_ds'),
+        ('events', 'events_function_native', 'event_timestamp')]
 
     try:
-        table_logs, table_debug, table_dataflow, table_function = source_bigquery_assets(client_bq, bigquery_asset_list)
+        table_logs, table_debug, _, table_function = source_bigquery_assets(client_bq, bigquery_asset_list)
     except Exception:
-        table_logs, table_debug, table_dataflow, table_function = generate_bigquery_assets(client_bq, bigquery_asset_list)
+        table_logs, table_debug, _, table_function = generate_bigquery_assets(client_bq, bigquery_asset_list)
 
     # Parse payload:
     payload = json.loads(base64.b64decode(data['data']).decode('utf-8'))
     bucket_name, object_location = payload['bucket'], payload['name']
-    gspath = 'gs://{bucket_name}/{object_location}'.format(bucket_name=bucket_name, object_location=object_location)
+    gspath = f'gs://{bucket_name}/{object_location}'
 
     # Write log to events_logs_function:
     errors = client_bq.insert_rows(table_logs, format_event_list(['parse_initiated'], str, os.environ['FUNCTION_NAME'], gspath))
     if errors:
-        print('Errors while inserting logs: {errors}'.format(errors=str(errors)))
+        print(f'Errors while inserting logs: {str(errors)}')
 
     # Get file from GCS:
     bucket = client_gcs.get_bucket(bucket_name)
-    blob = bucket.get_blob(object_location).download_as_string()
     try:
-        success, events_batch = try_parse_json(blob.decode('utf8'))
+        data = bucket.get_blob(object_location).download_as_string().decode('utf8')
     except UnicodeDecodeError:
         print('Automatic decompressive transcoding failed, unzipping content..')
-        success, events_batch = try_parse_json(gunzip_bytes_obj(blob))
+        data = gunzip_bytes_obj(bucket.get_blob(object_location).download_as_string())
+    except Exception:
+        raise Exception(f'Could not retrieve file gs://{bucket_name}/{object_location} from GCS!')
 
     # Parse list:
-    if success:
+    malformed, failed_insertion = False, False
+    for chunk in generator_chunk(generator_split(data, '\n'), 1000):
         events_batch_function, events_batch_debug = [], []
-        for event in events_batch:
-            d = {}
-            # Verify that the event has eventClass set to something:
-            d['event_class'] = get_dict_value(event, 'eventClass', 'event_class')
-            if d['event_class'] is not None:
-                # Sanitize:
-                d['analytics_environment'] = get_dict_value(event, 'analyticsEnvironment', 'analytics_environment')
-                d['event_environment'] = get_dict_value(event, 'eventEnvironment', 'event_environment')
-                d['event_source'] = get_dict_value(event, 'eventSource', 'event_source')
-                d['session_id'] = get_dict_value(event, 'sessionId', 'session_id')
-                d['version_id'] = get_dict_value(event, 'versionId', 'version_id')
-                d['batch_id'] = get_dict_value(event, 'batchId', 'batch_id')
-                d['event_id'] = get_dict_value(event, 'eventId', 'event_id')
-                d['event_index'] = get_dict_value(event, 'eventIndex', 'event_index')
-                # d['event_class'] = ...
-                d['event_type'] = get_dict_value(event, 'eventType', 'event_type')
-                d['player_id'] = get_dict_value(event, 'playerId', 'player_id')
-                d['event_timestamp'] = cast_to_unix_timestamp(get_dict_value(event, 'eventTimestamp', 'event_timestamp'), ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d %H:%M:%S %Z'])
-                d['received_timestamp'] = get_dict_value(event, 'receivedTimestamp', 'received_timestamp')  # This value was set by our endpoint, so we already know it is in unixtime
-                # Augment:
-                d['inserted_timestamp'] = time.time()
-                d['job_name'] = os.environ['FUNCTION_NAME']
-                # Sanitize:
-                d['event_attributes'] = get_dict_value(event, 'eventAttributes', 'event_attributes')
-                events_batch_function.append(d)
+        for event_tuple in generator_load_json(chunk):
+            if event_tuple[0]:
+                for event in event_tuple[1]:
+                    d = dict()
+                    # Sanitize:
+                    d['analytics_environment'] = get_dict_value(event, 'analyticsEnvironment', 'analytics_environment')
+                    d['event_environment'] = get_dict_value(event, 'eventEnvironment', 'event_environment')
+                    d['event_source'] = get_dict_value(event, 'eventSource', 'event_source')
+                    d['session_id'] = get_dict_value(event, 'sessionId', 'session_id')
+                    d['version_id'] = get_dict_value(event, 'versionId', 'version_id')
+                    d['batch_id'] = get_dict_value(event, 'batchId', 'batch_id')
+                    d['event_id'] = get_dict_value(event, 'eventId', 'event_id')
+                    d['event_index'] = get_dict_value(event, 'eventIndex', 'event_index')
+                    d['event_class'] = get_dict_value(event, 'eventClass', 'event_class')
+                    d['event_type'] = get_dict_value(event, 'eventType', 'event_type')
+                    d['player_id'] = get_dict_value(event, 'playerId', 'player_id')
+                    d['event_timestamp'] = cast_to_unix_timestamp(get_dict_value(event, 'eventTimestamp', 'event_timestamp'), ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%d %H:%M:%S %Z'])
+                    d['received_timestamp'] = get_dict_value(event, 'receivedTimestamp', 'received_timestamp')  # This value was set by our endpoint, so we already know it is in unixtime
+                    # Augment:
+                    d['inserted_timestamp'] = time.time()
+                    d['job_name'] = os.environ['FUNCTION_NAME']
+                    # Sanitize:
+                    d['event_attributes'] = get_dict_value(event, 'eventAttributes', 'event_attributes')
+                    events_batch_function.append(d)
             else:
-                events_batch_debug.append(event)
+                events_batch_debug.append(event_tuple[1])
 
         if len(events_batch_function) > 0:
-            # Write session JSON to events_function:
+            # Write JSON to events_function:
             errors = client_bq.insert_rows(table_function, events_batch_function)
             if errors:
-                print('Errors while inserting events: {errors}'.format(errors=str(errors)))
+                print(f'Errors while inserting events: {str(errors)}')
+                failed_insertion = True
 
         if len(events_batch_debug) > 0:
-            # Write non-session JSON to events_debug_function:
-            errors = client_bq.insert_rows(table_debug, format_event_list(events_batch_debug, dict, os.environ['FUNCTION_NAME'], gspath))
+            # Write non-JSON to events_debug_function:
+            errors = client_bq.insert_rows(table_debug, format_event_list(events_batch_debug, str, os.environ['FUNCTION_NAME'], gspath))
             if errors:
-                print('Errors while inserting events: {errors}'.format(errors=str(errors)))
+                print(f'Errors while inserting debug event: {str(errors)}')
+                failed_insertion = True
+            malformed = True
 
-    else:
-        # Write non-JSON to debugSink:
-        errors = client_bq.insert_rows(table_debug, format_event_list(events_batch, str, os.environ['FUNCTION_NAME'], gspath))
-        if errors:
-            print('Errors while inserting debug event: {errors}'.format(errors=str(errors)))
+    if failed_insertion and malformed:
+        raise Exception(f'Failed to insert records into BigQuery, inspect logs! Non-JSON data present in gs://{bucket_name}/{object_location}')
+    if failed_insertion:
+        raise Exception('Failed to insert records into BigQuery, inspect logs!')
+    if malformed:
+        raise Exception(f'Non-JSON data present in gs://{bucket_name}/{object_location}')
+
+    return 200

--- a/services/terraform/module-analytics/cloud-function.tf
+++ b/services/terraform/module-analytics/cloud-function.tf
@@ -22,10 +22,10 @@ resource "google_cloudfunctions_function" "function_analytics" {
   description           = "GCS to Native BigQuery Cloud Function"
   runtime               = "python37"
 
-  available_memory_mb   = 256
+  available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.functions_bucket.name
   source_archive_object = google_storage_bucket_object.function_analytics.name
-  timeout               = 60
+  timeout               = 180
   # The name of the Python function to invoke in ../../python/function/main.py:
   entry_point           = "ingest_into_native_bigquery_storage"
   service_account_email = google_service_account.cloud_function_gcs_to_bq.email


### PR DESCRIPTION
This PR optimizes the analytics Cloud Function's memory usage so it can use [the smallest / cheapest template](https://cloud.google.com/functions/pricing) (128 MB / 200 MHz).

The biggest file size our Cloud Endpoint currently accepts is 32MB - I have tested and verified files of this size still succeed. Another large scale test with many files of much smaller size also succeeded.

I've changed two additional minor things:

* Switched to use the latest Python 3 string formatting structure.
* It no longer silently INFO logs BigQuery insertion errors, but raises an Exception. 
