### PR TITLE
Upgrade BuildKite queue, fix analytics CI

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -5,7 +5,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "scaler_version=2"
-    - "queue=${CI_BUILDER_QUEUE:-v3-1570709272-becce6a62a8ff8e7-------z}"
+    - "queue=${CI_BUILDER_QUEUE:-v4-2020-01-06-bk5741-6b9203296b5a02de}"
   timeout_in_minutes: 5
   retry:
     automatic:

--- a/ci/analytics-endpoint.sh
+++ b/ci/analytics-endpoint.sh
@@ -43,7 +43,6 @@ imp-ci secrets read --environment=production --buildkite-org=improbable --secret
 cat /tmp/ci-online-services/secrets/analytics-gcs-writer-p12.json | jq -r .token > ${GOOGLE_SECRET_KEY_P12_ANALYTICS_GCS_WRITER}
 
 # Start a local pod containing both containers:
-netstat -lntp
 docker-compose -f services/docker/docker_compose_local_analytics_pipeline.yml up --no-start
 docker-compose -f services/docker/docker_compose_local_analytics_pipeline.yml start
 sleep 10
@@ -52,14 +51,14 @@ sleep 10
 API_KEY_TOKEN=$(echo $(cat ${API_KEY}) | jq -r .token)
 
 # Verify v1/event is working:
-POST=$(curl -s --request POST --header "content-type:application/json" --data "{\"eventSource\":\"client\",\"eventClass\":\"buildkite\",\"eventType\":\"docker-compose\",\"eventTimestamp\":1562599755,\"eventIndex\":6,\"sessionId\":\"f58179a375290599dde17f7c6d546d78\",\"versionId\":\"2.0.13\",\"eventEnvironment\":\"testing\",\"eventAttributes\":{\"playerId\": 12345678}}" "http://0.0.0.0:8080/v1/event?key=${API_KEY_TOKEN}&event_schema=improbable&event_category=external&event_environment=buildkite&session_id=f58179a375290599dde17f7c6d546d78")
+POST=$(curl -s --request POST --header "content-type:application/json" --data "{\"eventSource\":\"client\",\"eventClass\":\"buildkite\",\"eventType\":\"docker-compose\",\"eventTimestamp\":1562599755,\"eventIndex\":6,\"sessionId\":\"f58179a375290599dde17f7c6d546d78\",\"versionId\":\"2.0.13\",\"eventEnvironment\":\"testing\",\"eventAttributes\":{\"playerId\": 12345678}}" "http://0.0.0.0:9090/v1/event?key=${API_KEY_TOKEN}&event_schema=improbable&event_category=external&event_environment=buildkite&session_id=f58179a375290599dde17f7c6d546d78")
 echo ${POST}
 STATUS_CODE=$(echo ${POST} | jq .statusCode)
 echo ${STATUS_CODE}
 if [ "${STATUS_CODE}" != "200" ]; then echo 'Error: v1/event did not return 200!' && exit 1; fi;
 
 # Verify v1/file is working:
-POST=$(curl -s --request POST --header "content-type:application/json" --data "{\"content_type\":\"text/plain\", \"md5_digest\": \"XKvMhvwrORVuxdX54FQEdg==\"}" "http://0.0.0.0:8080/v1/file?key=${API_KEY_TOKEN}&file_category=file&file_parent=parent&file_child=child")
+POST=$(curl -s --request POST --header "content-type:application/json" --data "{\"content_type\":\"text/plain\", \"md5_digest\": \"XKvMhvwrORVuxdX54FQEdg==\"}" "http://0.0.0.0:9090/v1/file?key=${API_KEY_TOKEN}&file_category=file&file_parent=parent&file_child=child")
 echo ${POST}
 STATUS_CODE=$(echo ${POST} | jq .statusCode)
 echo ${STATUS_CODE}

--- a/ci/analytics-endpoint.sh
+++ b/ci/analytics-endpoint.sh
@@ -43,7 +43,9 @@ imp-ci secrets read --environment=production --buildkite-org=improbable --secret
 cat /tmp/ci-online-services/secrets/analytics-gcs-writer-p12.json | jq -r .token > ${GOOGLE_SECRET_KEY_P12_ANALYTICS_GCS_WRITER}
 
 # Start a local pod containing both containers:
-docker-compose -f services/docker/docker_compose_local_analytics_pipeline.yml up --force-recreate --detach && sleep 10
+docker-compose -f services/docker/docker_compose_local_analytics_pipeline.yml up --no-start
+docker-compose -f services/docker/docker_compose_local_analytics_pipeline.yml start
+sleep 10
 
 # Parse API key:
 API_KEY_TOKEN=$(echo $(cat ${API_KEY}) | jq -r .token)

--- a/ci/analytics-endpoint.sh
+++ b/ci/analytics-endpoint.sh
@@ -43,6 +43,7 @@ imp-ci secrets read --environment=production --buildkite-org=improbable --secret
 cat /tmp/ci-online-services/secrets/analytics-gcs-writer-p12.json | jq -r .token > ${GOOGLE_SECRET_KEY_P12_ANALYTICS_GCS_WRITER}
 
 # Start a local pod containing both containers:
+netstat -lntp
 docker-compose -f services/docker/docker_compose_local_analytics_pipeline.yml up --no-start
 docker-compose -f services/docker/docker_compose_local_analytics_pipeline.yml start
 sleep 10

--- a/docs/content/services-packages/analytics-pipeline/local.md
+++ b/docs/content/services-packages/analytics-pipeline/local.md
@@ -59,7 +59,7 @@ docker-compose -f services/docker/docker_compose_local_analytics_pipeline.yml up
 5\. Replace `{{your_analytics_api_key}}` with your API key in the curl request below and submit it in your terminal:
 
 ```sh
-curl --request POST --header "Content-Type:application/json" --data "{\"eventSource\":\"client\",\"eventClass\":\"docs\",\"eventType\":\"endpoint_docker_compose\",\"eventTimestamp\":1562599755,\"eventIndex\":6,\"sessionId\":\"f58179a375290599dde17f7c6d546d78\",\"versionId\":\"0.2.0\",\"eventEnvironment\":\"testing\",\"eventAttributes\":{\"playerId\": 12345678}}" "http://0.0.0.0:8080/v1/event?key={{your_analytics_api_key}}&event_schema=improbable&event_category=external&event_environment=debug&session_id=f58179a375290599dde17f7c6d546d78"
+curl --request POST --header "Content-Type:application/json" --data "{\"eventSource\":\"client\",\"eventClass\":\"docs\",\"eventType\":\"endpoint_docker_compose\",\"eventTimestamp\":1562599755,\"eventIndex\":6,\"sessionId\":\"f58179a375290599dde17f7c6d546d78\",\"versionId\":\"0.2.0\",\"eventEnvironment\":\"testing\",\"eventAttributes\":{\"playerId\": 12345678}}" "http://0.0.0.0:9090/v1/event?key={{your_analytics_api_key}}&event_schema=improbable&event_category=external&event_environment=debug&session_id=f58179a375290599dde17f7c6d546d78"
 ```
 
 A successful response looks like:

--- a/services/docker/docker_compose_local_analytics_pipeline.yml
+++ b/services/docker/docker_compose_local_analytics_pipeline.yml
@@ -5,7 +5,7 @@ services:
   analytics-esp:
     image: "gcr.io/endpoints-release/endpoints-runtime:1.38.0"
     ports:
-      - "8080:8080"
+      - "9090:8080"
     volumes:
       - "${GOOGLE_SECRET_KEY_JSON_ANALYTICS_ENDPOINT}:/secrets/json/analytics-endpoint.json"
     command:


### PR DESCRIPTION
The new BuildKite images run a Goss status check on port 8080, so this also tweaks the local docker-compose configuration to expose the analytics service on host port 9090.