### PR TITLE
Update CI agent targeting rules

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -2,15 +2,20 @@
 common: &common
   agents:
     - "capable_of_building=online-services"
-    - "environment=production"
+    - "environment=${CI_ENVIRONMENT:-production}"
+    - "machine_type=single"
+    - "node_stability=interruptible"
     - "permission_set=builder"
-    - "scaler_version=2"
+    - "platform=linux"
     - "queue=${CI_BUILDER_QUEUE:-v4-2020-01-06-bk5741-6b9203296b5a02de}"
+    - "scaler_version=2"
   timeout_in_minutes: 5
   retry:
     automatic:
         # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
       - exit_status: -1
+        limit: 3
+      - exit_status: 255
         limit: 3
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.


### PR DESCRIPTION
Added some missing definitions to more tightly target agents. https://docs.improbable.io/internal/platform/product-groups/dev-workflow/buildkite/how-to-autoscale-agents-to-match-demand
* node_stability = interruptible so that there's an 80% reduction in compute spend for the tradeoff of an agent node being shut down at random within 24 hours of being started. Since your jobs all seem to be sub five minutes, that seems like a very worthwhile tradeoff.
* make environment overridable via a var
* specify a machine_type to be explicit (same naming as spatialOS node sizes)
* specify a platform to be explicit (we're planning on soon making it possible for a single queue to contain more than one image)

Add another BK-system-error code for auto-retry.